### PR TITLE
feat(ui): migrate shared layout and feature widgets off Angular Material

### DIFF
--- a/public/icons.svg
+++ b/public/icons.svg
@@ -1,0 +1,30 @@
+<svg xmlns="http://www.w3.org/2000/svg" style="display:none">
+  <symbol id="account_circle" viewBox="0 0 24 24"><circle cx="12" cy="8" r="4"></circle><path d="M4 20c1.8-3.5 5-5 8-5s6.2 1.5 8 5"></path></symbol>
+  <symbol id="logout" viewBox="0 0 24 24"><path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4"></path><path d="M16 17l5-5-5-5"></path><path d="M21 12H9"></path></symbol>
+  <symbol id="home" viewBox="0 0 24 24"><path d="M3 11.5L12 4l9 7.5"></path><path d="M5 10.5V20h14v-9.5"></path></symbol>
+  <symbol id="menu_book" viewBox="0 0 24 24"><path d="M4 5a3 3 0 0 1 3-3h13v18H7a3 3 0 0 0-3 3z"></path><path d="M7 2v18"></path></symbol>
+  <symbol id="receipt_long" viewBox="0 0 24 24"><path d="M6 2h12v20l-2-1.5L14 22l-2-1.5L10 22l-2-1.5L6 22z"></path><path d="M9 7h6M9 11h6M9 15h4"></path></symbol>
+  <symbol id="point_of_sale" viewBox="0 0 24 24"><rect x="3" y="5" width="18" height="14" rx="2"></rect><path d="M7 9h4M7 13h2M15 9h2M15 13h2"></path></symbol>
+  <symbol id="inventory_2" viewBox="0 0 24 24"><path d="M3 7h18l-2 13H5z"></path><path d="M9 7V5a3 3 0 0 1 6 0v2"></path></symbol>
+  <symbol id="people" viewBox="0 0 24 24"><circle cx="9" cy="8" r="3"></circle><circle cx="17" cy="9" r="2.5"></circle><path d="M3 19c1.2-2.6 3.3-4 6-4s4.8 1.4 6 4"></path><path d="M14 19c.7-1.7 2-2.7 3.8-2.9"></path></symbol>
+  <symbol id="share" viewBox="0 0 24 24"><circle cx="18" cy="5" r="2.5"></circle><circle cx="6" cy="12" r="2.5"></circle><circle cx="18" cy="19" r="2.5"></circle><path d="M8.2 11l7.6-4.2M8.2 13l7.6 4.2"></path></symbol>
+  <symbol id="print" viewBox="0 0 24 24"><path d="M7 9V4h10v5"></path><rect x="6" y="14" width="12" height="6"></rect><path d="M6 11H5a2 2 0 0 0-2 2v3h3"></path><path d="M18 16h3v-3a2 2 0 0 0-2-2h-1"></path></symbol>
+  <symbol id="add" viewBox="0 0 24 24"><path d="M12 5v14M5 12h14"></path></symbol>
+  <symbol id="list" viewBox="0 0 24 24"><path d="M8 6h13M8 12h13M8 18h13"></path><circle cx="4" cy="6" r="1"></circle><circle cx="4" cy="12" r="1"></circle><circle cx="4" cy="18" r="1"></circle></symbol>
+  <symbol id="warning" viewBox="0 0 24 24"><path d="M12 3l10 18H2z"></path><path d="M12 9v5"></path><circle cx="12" cy="17" r="1"></circle></symbol>
+  <symbol id="egg" viewBox="0 0 24 24"><path d="M12 3c3.5 0 6 5 6 10a6 6 0 1 1-12 0c0-5 2.5-10 6-10z"></path></symbol>
+  <symbol id="history" viewBox="0 0 24 24"><path d="M3 12a9 9 0 1 0 3-6.7"></path><path d="M3 4v5h5"></path><path d="M12 8v5l3 2"></path></symbol>
+  <symbol id="calculate" viewBox="0 0 24 24"><rect x="6" y="3" width="12" height="18" rx="2"></rect><path d="M9 7h6M9 11h2M13 11h2M9 15h2M13 15h2"></path></symbol>
+  <symbol id="phone" viewBox="0 0 24 24"><path d="M22 16.9v3a2 2 0 0 1-2.2 2A19.8 19.8 0 0 1 2.1 4.2 2 2 0 0 1 4.1 2h3a2 2 0 0 1 2 1.7c.2 1.2.5 2.3.9 3.4a2 2 0 0 1-.5 2.1L8.1 10.6a16 16 0 0 0 5.3 5.3l1.4-1.4a2 2 0 0 1 2.1-.5c1.1.4 2.2.7 3.4.9a2 2 0 0 1 1.7 2z"></path></symbol>
+  <symbol id="place" viewBox="0 0 24 24"><path d="M12 22s7-6 7-12a7 7 0 1 0-14 0c0 6 7 12 7 12z"></path><circle cx="12" cy="10" r="2.5"></circle></symbol>
+  <symbol id="chat" viewBox="0 0 24 24"><path d="M21 12a8 8 0 0 1-8 8H6l-3 3V12a8 8 0 0 1 8-8h2a8 8 0 0 1 8 8z"></path></symbol>
+  <symbol id="trending_up" viewBox="0 0 24 24"><path d="M3 17l7-7 4 4 7-7"></path><path d="M14 7h7v7"></path></symbol>
+  <symbol id="savings" viewBox="0 0 24 24"><path d="M4 9h16v8a3 3 0 0 1-3 3H7a3 3 0 0 1-3-3z"></path><path d="M8 9V6h8v3"></path><circle cx="12" cy="14" r="2"></circle></symbol>
+  <symbol id="pending_actions" viewBox="0 0 24 24"><path d="M8 6h13M8 12h13M8 18h8"></path><circle cx="4" cy="6" r="1"></circle><circle cx="4" cy="12" r="1"></circle><circle cx="4" cy="18" r="1"></circle></symbol>
+  <symbol id="emoji_events" viewBox="0 0 24 24"><path d="M7 4h10v3a5 5 0 0 1-10 0z"></path><path d="M9 17h6M10 20h4"></path><path d="M5 6h2a4 4 0 0 1-4 4V8a2 2 0 0 1 2-2zm14 0h-2a4 4 0 0 0 4 4V8a2 2 0 0 0-2-2z"></path></symbol>
+  <symbol id="error" viewBox="0 0 24 24"><circle cx="12" cy="12" r="9"></circle><path d="M12 8v5"></path><circle cx="12" cy="16" r="1"></circle></symbol>
+  <symbol id="receipt" viewBox="0 0 24 24"><path d="M6 2h12v20l-2-1.5L14 22l-2-1.5L10 22l-2-1.5L6 22z"></path><path d="M9 7h6M9 11h6M9 15h6"></path></symbol>
+  <symbol id="check_circle" viewBox="0 0 24 24"><circle cx="12" cy="12" r="9"></circle><path d="M8 12l3 3 5-5"></path></symbol>
+  <symbol id="more_vert" viewBox="0 0 24 24"><circle cx="12" cy="5" r="1"></circle><circle cx="12" cy="12" r="1"></circle><circle cx="12" cy="19" r="1"></circle></symbol>
+  <symbol id="content_copy" viewBox="0 0 24 24"><rect x="9" y="9" width="11" height="11" rx="2"></rect><path d="M5 15V5h10"></path></symbol>
+</svg>

--- a/src/app/features/customers/customers.component.html
+++ b/src/app/features/customers/customers.component.html
@@ -9,7 +9,7 @@
 
 @if (filteredCustomers().length === 0) {
   <div class="text-center py-8 text-gray-400">
-    <mat-icon style="font-size: 48px; width: 48px; height: 48px">people</mat-icon>
+    <ui-icon name="people" [size]="48" [decorative]="true" />
     @if (searchTerm()) {
       <p>No se encontraron clientes</p>
     } @else {
@@ -20,38 +20,33 @@
 }
 
 @for (customer of filteredCustomers(); track customer.id) {
-  <mat-card class="touch-card mb-3" (click)="edit(customer)">
-    <mat-card-content class="flex items-center justify-between py-2">
+  <article class="ui-card-surface touch-card mb-3" (click)="edit(customer)">
+    <div class="flex items-center justify-between py-2">
       <div>
         <div class="font-medium">{{ customer.name }}</div>
         @if (customer.phone) {
-          <div class="text-sm text-gray-500">
-            <mat-icon class="icon-sm">phone</mat-icon> {{ customer.phone }}
+          <div class="text-sm text-gray-500 flex items-center gap-1">
+            <ui-icon name="phone" class="icon-sm" [size]="14" [decorative]="true" /> {{ customer.phone }}
           </div>
         }
         @if (customer.address) {
-          <div class="text-sm text-gray-500">
-            <mat-icon class="icon-sm">place</mat-icon> {{ customer.address }}
+          <div class="text-sm text-gray-500 flex items-center gap-1">
+            <ui-icon name="place" class="icon-sm" [size]="14" [decorative]="true" /> {{ customer.address }}
           </div>
         }
       </div>
       <div class="text-right flex flex-col items-end gap-1">
         <div class="text-sm text-gray-400">{{ customer.totalPurchases }} compras</div>
         @if (customer.phone) {
-          <button
-            mat-icon-button
-            color="primary"
-            (click)="openWhatsApp(customer, $event)"
-            aria-label="Enviar WhatsApp"
-          >
-            <mat-icon>chat</mat-icon>
+          <button class="ui-icon-btn" (click)="openWhatsApp(customer, $event)" aria-label="Enviar WhatsApp" type="button">
+            <ui-icon name="chat" [decorative]="true" />
           </button>
         }
       </div>
-    </mat-card-content>
-  </mat-card>
+    </div>
+  </article>
 }
 
-<button mat-fab class="fab-bottom-right" color="primary" (click)="create()">
-  <mat-icon>add</mat-icon>
+<button class="fab-bottom-right ui-fab" (click)="create()" type="button" aria-label="Agregar cliente">
+  <ui-icon name="add" [decorative]="true" />
 </button>

--- a/src/app/features/customers/customers.component.ts
+++ b/src/app/features/customers/customers.component.ts
@@ -1,17 +1,15 @@
 import { ChangeDetectionStrategy, Component, computed, inject, signal } from '@angular/core';
-import { MatCardModule } from '@angular/material/card';
-import { MatIconModule } from '@angular/material/icon';
-import { MatButtonModule } from '@angular/material/button';
 import { NotificationService } from '../../core/services/notification.service';
 import { CustomersStore } from '../../core/store/customers.store';
 import { WhatsAppService } from '../../core/services/whatsapp.service';
 import { Customer } from '../../core/models/customer';
 import { CustomerFormComponent } from './customer-form.component';
 import { DialogService } from '../../core/services/dialog.service';
+import { UiIconComponent } from '../../shared/ui/components';
 
 @Component({
   selector: 'app-customers',
-  imports: [MatCardModule, MatIconModule, MatButtonModule],
+  imports: [UiIconComponent],
   templateUrl: './customers.component.html',
   styleUrl: './customers.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/src/app/features/dashboard/dashboard.component.html
+++ b/src/app/features/dashboard/dashboard.component.html
@@ -1,167 +1,105 @@
 <h2 class="text-xl font-semibold mb-4">Hola! 👋</h2>
 
-<!-- Period Selector -->
-<mat-button-toggle-group
-  class="mb-4 w-full"
-  [value]="store.selectedPeriod()"
-  (change)="store.setPeriod($event.value)"
->
-  <mat-button-toggle value="month" class="flex-1">Mes</mat-button-toggle>
-</mat-button-toggle-group>
-
-<!-- KPI Cards -->
-<div class="grid grid-cols-2 gap-3 mb-6">
-  <mat-card class="touch-card">
-    <mat-card-content class="text-center py-3">
-      <mat-icon class="text-green-600">trending_up</mat-icon>
-      <div class="text-2xl font-bold">{{ monthlySales() | ars }}</div>
-      <div class="text-xs text-gray-500">Ingresos</div>
-    </mat-card-content>
-  </mat-card>
-
-  <mat-card class="touch-card">
-    <mat-card-content class="text-center py-3">
-      <mat-icon class="text-blue-600">savings</mat-icon>
-      <div
-        class="text-2xl font-bold"
-        [class]="netProfit() >= 0 ? 'text-blue-700' : 'text-red-600'"
-      >
-        {{ netProfit() | ars }}
-      </div>
-      <div class="text-xs text-gray-500">Ganancia neta</div>
-    </mat-card-content>
-  </mat-card>
-
-  <mat-card class="touch-card" routerLink="/recetas">
-    <mat-card-content class="text-center py-3">
-      <mat-icon class="text-purple-600">menu_book</mat-icon>
-      <div class="text-2xl font-bold">{{ totalRecipes() }}</div>
-      <div class="text-xs text-gray-500">Recetas activas</div>
-    </mat-card-content>
-  </mat-card>
-
-  <mat-card class="touch-card" routerLink="/ventas">
-    <mat-card-content class="text-center py-3">
-      <mat-icon class="text-orange-600">pending_actions</mat-icon>
-      <div class="text-2xl font-bold">{{ pendingOrders() }}</div>
-      <div class="text-xs text-gray-500">Pedidos pendientes</div>
-    </mat-card-content>
-  </mat-card>
+<div class="ui-toggle-group mb-4">
+  <button class="ui-toggle active" type="button" aria-pressed="true" (click)="store.setPeriod('month')">Mes</button>
 </div>
 
-<!-- Top selling product -->
+<div class="grid grid-cols-2 gap-3 mb-6">
+  <article class="ui-card-surface touch-card text-center py-3">
+    <ui-icon name="trending_up" class="text-green-600" [decorative]="true" />
+    <div class="text-2xl font-bold">{{ monthlySales() | ars }}</div>
+    <div class="text-xs text-gray-500">Ingresos</div>
+  </article>
+
+  <article class="ui-card-surface touch-card text-center py-3">
+    <ui-icon name="savings" class="text-blue-600" [decorative]="true" />
+    <div class="text-2xl font-bold" [class]="netProfit() >= 0 ? 'text-blue-700' : 'text-red-600'">
+      {{ netProfit() | ars }}
+    </div>
+    <div class="text-xs text-gray-500">Ganancia neta</div>
+  </article>
+
+  <article class="ui-card-surface touch-card text-center py-3" routerLink="/recetas">
+    <ui-icon name="menu_book" class="text-purple-600" [decorative]="true" />
+    <div class="text-2xl font-bold">{{ totalRecipes() }}</div>
+    <div class="text-xs text-gray-500">Recetas activas</div>
+  </article>
+
+  <article class="ui-card-surface touch-card text-center py-3" routerLink="/ventas">
+    <ui-icon name="pending_actions" class="text-orange-600" [decorative]="true" />
+    <div class="text-2xl font-bold">{{ pendingOrders() }}</div>
+    <div class="text-xs text-gray-500">Pedidos pendientes</div>
+  </article>
+</div>
+
 @if (store.topSellingProduct(); as top) {
-  <mat-card class="mb-4 touch-card">
-    <mat-card-content class="flex items-center gap-3 py-2">
-      <mat-icon class="text-amber-500" style="font-size: 32px; width: 32px; height: 32px"
-        >emoji_events</mat-icon
-      >
-      <div>
-        <div class="text-xs text-gray-500">Más vendido</div>
-        <div class="font-bold">{{ top.name }}</div>
-        <div class="text-sm text-gray-400">{{ top.quantity }} unidades</div>
-      </div>
-    </mat-card-content>
-  </mat-card>
+  <article class="ui-card-surface mb-4 touch-card flex items-center gap-3 py-2">
+    <ui-icon name="emoji_events" class="text-amber-500" [size]="32" [decorative]="true" />
+    <div>
+      <div class="text-xs text-gray-500">Más vendido</div>
+      <div class="font-bold">{{ top.name }}</div>
+      <div class="text-sm text-gray-400">{{ top.quantity }} unidades</div>
+    </div>
+  </article>
 }
 
-<!-- Income vs Expenses Bar -->
 <h3 class="text-base font-medium mb-2">Ingresos vs Gastos</h3>
-<mat-card class="mb-4">
-  <mat-card-content class="py-3 flex flex-col">
-    <div class="flex items-center gap-2 py-2">
-      <span class="text-xs w-20 text-gray-500 shrink-0">Ingresos</span>
-      <div class="flex-1 bg-gray-100 rounded-full h-6 overflow-hidden">
-        <div
-          class="bg-green-500 h-6 rounded-full transition-all"
-          [style.width.%]="incomeBarWidth()"
-        ></div>
-      </div>
-      <span class="text-xs w-24 text-right font-medium shrink-0">{{ monthlySales() | ars }}</span>
-    </div>
-    <div class="border-t border-dashed border-gray-200"></div>
-    <div class="flex items-center gap-2 py-2">
-      <span class="text-xs w-20 text-gray-500 shrink-0">Ingredientes</span>
-      <div class="flex-1 bg-gray-100 rounded-full h-6 overflow-hidden">
-        <div
-          class="bg-orange-400 h-6 rounded-full transition-all"
-          [style.width.%]="ingredientsBarWidth()"
-        ></div>
-      </div>
-      <span class="text-xs w-24 text-right font-medium shrink-0">{{ monthlyExpenses() | ars }}</span>
-    </div>
-    <div class="flex items-center gap-2 pb-2">
-      <span class="text-xs w-20 text-gray-500 shrink-0">C. fijos</span>
-      <div class="flex-1 bg-gray-100 rounded-full h-6 overflow-hidden">
-        <div
-          class="bg-red-400 h-6 rounded-full transition-all"
-          [style.width.%]="fixedCostsBarWidth()"
-        ></div>
-      </div>
-      <span class="text-xs w-24 text-right font-medium shrink-0">{{
-        periodFixedCosts() | ars
-      }}</span>
-    </div>
-    <div class="border-t pt-3 flex items-center justify-between">
-      <span class="text-xs text-gray-500">Gastos totales</span>
-      <span class="text-sm font-semibold text-red-700">{{ totalPeriodExpenses() | ars }}</span>
-    </div>
-    <div class="pt-1 flex items-center justify-between">
-      <span class="text-xs text-gray-500">Ganancia neta</span>
-      <span
-        class="text-sm font-bold"
-        [class]="netProfit() >= 0 ? 'text-green-700' : 'text-red-700'"
-      >
-        {{ netProfit() | ars }}
-      </span>
-    </div>
-  </mat-card-content>
-</mat-card>
+<section class="ui-card-surface mb-4 py-3 flex flex-col">
+  <div class="flex items-center gap-2 py-2">
+    <span class="text-xs w-20 text-gray-500 shrink-0">Ingresos</span>
+    <div class="flex-1 ui-progress"><div class="ui-progress__bar bg-green-500" [style.width.%]="incomeBarWidth()"></div></div>
+    <span class="text-xs w-24 text-right font-medium shrink-0">{{ monthlySales() | ars }}</span>
+  </div>
+  <div class="border-t border-dashed border-gray-200"></div>
+  <div class="flex items-center gap-2 py-2">
+    <span class="text-xs w-20 text-gray-500 shrink-0">Ingredientes</span>
+    <div class="flex-1 ui-progress"><div class="ui-progress__bar bg-orange-400" [style.width.%]="ingredientsBarWidth()"></div></div>
+    <span class="text-xs w-24 text-right font-medium shrink-0">{{ monthlyExpenses() | ars }}</span>
+  </div>
+  <div class="flex items-center gap-2 pb-2">
+    <span class="text-xs w-20 text-gray-500 shrink-0">C. fijos</span>
+    <div class="flex-1 ui-progress"><div class="ui-progress__bar bg-red-400" [style.width.%]="fixedCostsBarWidth()"></div></div>
+    <span class="text-xs w-24 text-right font-medium shrink-0">{{ periodFixedCosts() | ars }}</span>
+  </div>
+  <div class="border-t pt-3 flex items-center justify-between">
+    <span class="text-xs text-gray-500">Gastos totales</span>
+    <span class="text-sm font-semibold text-red-700">{{ totalPeriodExpenses() | ars }}</span>
+  </div>
+  <div class="pt-1 flex items-center justify-between">
+    <span class="text-xs text-gray-500">Ganancia neta</span>
+    <span class="text-sm font-bold" [class]="netProfit() >= 0 ? 'text-green-700' : 'text-red-700'">{{ netProfit() | ars }}</span>
+  </div>
+</section>
 
-<!-- Stock Alerts -->
 @if (lowStock().length > 0) {
-  <h3 class="text-base font-medium mb-2">
-    <mat-icon class="text-red-500 align-middle" style="font-size: 20px">warning</mat-icon>
+  <h3 class="text-base font-medium mb-2 flex items-center gap-1">
+    <ui-icon name="warning" class="text-red-500" [size]="20" [decorative]="true" />
     Stock bajo
   </h3>
-  <mat-card class="mb-4">
-    <mat-list>
-      @for (item of lowStock(); track item.id) {
-        <mat-list-item>
-          <mat-icon matListItemIcon class="stock-danger">error</mat-icon>
-          <span matListItemTitle>{{ item.name }}</span>
-          <span matListItemLine>
-            Quedan {{ item.currentStock }} {{ item.unit }} (mín: {{ item.minimumStock }})
-          </span>
-        </mat-list-item>
-      }
-    </mat-list>
-  </mat-card>
+  <section class="ui-card-surface mb-4 ui-list">
+    @for (item of lowStock(); track item.id) {
+      <article class="ui-list-item">
+        <ui-icon name="error" class="stock-danger" [size]="18" [decorative]="true" />
+        <div>
+          <div class="font-medium">{{ item.name }}</div>
+          <div class="text-xs text-gray-500">Quedan {{ item.currentStock }} {{ item.unit }} (mín: {{ item.minimumStock }})</div>
+        </div>
+      </article>
+    }
+  </section>
 }
 
-<!-- Recent Sales -->
 @if (recentSales().length > 0) {
   <h3 class="text-base font-medium mb-2">Últimas ventas</h3>
-  <mat-card>
-    <mat-list>
-      @for (sale of recentSales(); track sale.id) {
-        <mat-list-item>
-          <mat-icon matListItemIcon>receipt</mat-icon>
-          <span matListItemTitle
-            >{{ sale.customerName || 'Sin cliente' }} — {{ sale.total | ars }}</span
-          >
-          <span matListItemLine>
-            <mat-chip-set>
-              <mat-chip
-                [class]="sale.status === 'pending' ? 'stock-warning' : 'stock-ok'"
-                style="font-size: 11px"
-              >
-                {{ sale.status }}
-              </mat-chip>
-            </mat-chip-set>
-          </span>
-        </mat-list-item>
-      }
-    </mat-list>
-  </mat-card>
+  <section class="ui-card-surface ui-list">
+    @for (sale of recentSales(); track sale.id) {
+      <article class="ui-list-item">
+        <ui-icon name="receipt" [size]="18" [decorative]="true" />
+        <div class="flex items-center justify-between gap-2">
+          <span>{{ sale.customerName || 'Sin cliente' }} — {{ sale.total | ars }}</span>
+          <span class="ui-chip-static" [class]="sale.status === 'pending' ? 'stock-warning' : 'stock-ok'">{{ sale.status }}</span>
+        </div>
+      </article>
+    }
+  </section>
 }

--- a/src/app/features/dashboard/dashboard.component.scss
+++ b/src/app/features/dashboard/dashboard.component.scss
@@ -1,0 +1,3 @@
+:host {
+  display: block;
+}

--- a/src/app/features/dashboard/dashboard.component.ts
+++ b/src/app/features/dashboard/dashboard.component.ts
@@ -1,28 +1,17 @@
 import { ChangeDetectionStrategy, Component, computed, inject } from '@angular/core';
-import { MatCardModule } from '@angular/material/card';
-import { MatIconModule } from '@angular/material/icon';
-import { MatListModule } from '@angular/material/list';
-import { MatChipsModule } from '@angular/material/chips';
-import { MatButtonToggleModule } from '@angular/material/button-toggle';
 import { RouterLink } from '@angular/router';
 import { DashboardStore } from '../../core/store/dashboard.store';
 import { IngredientsStore } from '../../core/store/ingredients.store';
 import { SalesStore } from '../../core/store/sales.store';
 import { RecipesStore } from '../../core/store/recipes.store';
 import { ArsPipe } from '../../shared/pipes/ars.pipe';
+import { UiIconComponent } from '../../shared/ui/components';
 
 @Component({
   selector: 'app-dashboard',
-  imports: [
-    MatCardModule,
-    MatIconModule,
-    MatListModule,
-    MatChipsModule,
-    MatButtonToggleModule,
-    RouterLink,
-    ArsPipe,
-  ],
+  imports: [RouterLink, ArsPipe, UiIconComponent],
   templateUrl: './dashboard.component.html',
+  styleUrl: './dashboard.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class DashboardComponent {
@@ -37,7 +26,6 @@ export class DashboardComponent {
   pendingOrders = this.salesStore.pendingOrdersCount;
   monthlySales = this.store.monthlySales;
   monthlyExpenses = this.store.monthlyExpenses;
-  monthlyProfit = this.store.monthlyProfit;
   periodFixedCosts = this.store.periodFixedCosts;
   totalPeriodExpenses = this.store.totalPeriodExpenses;
   netProfit = this.store.netProfit;

--- a/src/app/features/fixed-costs/fixed-costs.component.html
+++ b/src/app/features/fixed-costs/fixed-costs.component.html
@@ -2,38 +2,31 @@
   <h2 class="text-xl font-semibold">Costos Fijos</h2>
 </div>
 
-<!-- Resumen mensual -->
-<mat-card class="mb-4 bg-orange-50">
-  <mat-card-content class="py-3">
+<section class="ui-card-surface mb-4 bg-orange-50">
+  <div class="py-3">
     <div class="flex items-center gap-2 mb-1">
-      <mat-icon class="text-orange-500">calculate</mat-icon>
+      <ui-icon name="calculate" class="text-orange-500" [decorative]="true" />
       <span class="font-medium text-orange-800">Total mensual estimado</span>
     </div>
-    <div class="text-2xl font-bold text-orange-700">
-      {{ store.totalMonthlyFixedCosts() | ars }}
-    </div>
+    <div class="text-2xl font-bold text-orange-700">{{ store.totalMonthlyFixedCosts() | ars }}</div>
     <div class="text-xs text-orange-600 mt-1">Suma de todos los costos convertidos a mensual</div>
-  </mat-card-content>
-</mat-card>
+  </div>
+</section>
 
-<!-- Lista vacía -->
 @if (store.fixedCosts().length === 0) {
   <div class="text-center py-8 text-gray-400">
-    <mat-icon style="font-size: 48px; width: 48px; height: 48px">receipt_long</mat-icon>
+    <ui-icon name="receipt_long" [size]="48" [decorative]="true" />
     <p>No hay costos fijos cargados</p>
     <p class="text-sm">Tocá el botón + para agregar luz, gas, alquiler, etc.</p>
   </div>
 }
 
-<!-- Agrupado por categoría -->
 @for (group of groupsByCategory(); track group.category) {
   <div class="mb-2">
-    <div class="text-xs font-semibold text-gray-500 uppercase tracking-wide px-1 mb-1">
-      {{ categoryLabel(group.category) }}
-    </div>
+    <div class="text-xs font-semibold text-gray-500 uppercase tracking-wide px-1 mb-1">{{ categoryLabel(group.category) }}</div>
     @for (cost of group.items; track cost.id) {
-      <mat-card class="touch-card mb-2" (click)="auth.isOwner() ? edit(cost) : null">
-        <mat-card-content class="py-2">
+      <article class="ui-card-surface touch-card mb-2" (click)="auth.isOwner() ? edit(cost) : null">
+        <div class="py-2">
           <div class="flex items-center justify-between">
             <div class="flex-1 min-w-0">
               <div class="font-medium truncate">{{ cost.name }}</div>
@@ -43,28 +36,20 @@
             </div>
             <div class="text-right ml-3 shrink-0">
               <div class="font-semibold text-orange-700">{{ cost.amount | ars }}</div>
-              <mat-chip-set>
-                <mat-chip class="text-xs">{{ frequencyLabel(cost.frequency) }}</mat-chip>
-              </mat-chip-set>
+              <span class="ui-chip-static">{{ frequencyLabel(cost.frequency) }}</span>
             </div>
           </div>
           @if (cost.frequency !== 'monthly') {
             <div class="text-xs text-gray-400 mt-1">≈ {{ monthlyAmount(cost) | ars }}/mes</div>
           }
-        </mat-card-content>
-      </mat-card>
+        </div>
+      </article>
     }
   </div>
 }
 
 @if (auth.isOwner()) {
-  <button
-    mat-fab
-    class="fab-bottom-right"
-    color="primary"
-    (click)="create()"
-    aria-label="Agregar costo fijo"
-  >
-    <mat-icon>add</mat-icon>
+  <button class="fab-bottom-right ui-fab" (click)="create()" aria-label="Agregar costo fijo" type="button">
+    <ui-icon name="add" [decorative]="true" />
   </button>
 }

--- a/src/app/features/fixed-costs/fixed-costs.component.scss
+++ b/src/app/features/fixed-costs/fixed-costs.component.scss
@@ -1,0 +1,3 @@
+:host {
+  display: block;
+}

--- a/src/app/features/fixed-costs/fixed-costs.component.ts
+++ b/src/app/features/fixed-costs/fixed-costs.component.ts
@@ -1,8 +1,4 @@
-import { Component, inject, ChangeDetectionStrategy } from '@angular/core';
-import { MatCardModule } from '@angular/material/card';
-import { MatIconModule } from '@angular/material/icon';
-import { MatButtonModule } from '@angular/material/button';
-import { MatChipsModule } from '@angular/material/chips';
+import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
 import { NotificationService } from '../../core/services/notification.service';
 import { FixedCostsStore } from '../../core/store/fixed-costs.store';
 import { AuthService } from '../../core/services/auth.service';
@@ -15,12 +11,14 @@ import {
 import { FixedCostFormComponent } from './fixed-cost-form.component';
 import { ArsPipe } from '../../shared/pipes/ars.pipe';
 import { DialogService } from '../../core/services/dialog.service';
+import { UiIconComponent } from '../../shared/ui/components';
 
 @Component({
   selector: 'app-fixed-costs',
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [MatCardModule, MatIconModule, MatButtonModule, MatChipsModule, ArsPipe],
+  imports: [ArsPipe, UiIconComponent],
   templateUrl: './fixed-costs.component.html',
+  styleUrl: './fixed-costs.component.scss',
 })
 export class FixedCostsComponent {
   readonly store = inject(FixedCostsStore);

--- a/src/app/features/ingredients/ingredients.component.html
+++ b/src/app/features/ingredients/ingredients.component.html
@@ -9,7 +9,7 @@
 
 @if (filteredIngredients().length === 0) {
   <div class="text-center py-8 text-gray-400">
-    <mat-icon style="font-size: 48px; width: 48px; height: 48px">egg</mat-icon>
+    <ui-icon name="egg" [size]="48" [decorative]="true" />
     @if (searchTerm()) {
       <p>No se encontraron ingredientes</p>
     } @else {
@@ -20,34 +20,27 @@
 }
 
 @for (ingredient of filteredIngredients(); track ingredient.id) {
-  <mat-card class="touch-card mb-3" (click)="auth.isOwner() ? edit(ingredient) : null">
-    <mat-card-content class="flex items-center justify-between py-2">
+  <article class="ui-card-surface touch-card mb-3" (click)="auth.isOwner() ? edit(ingredient) : null">
+    <div class="flex items-center justify-between py-2">
       <div>
         <div class="font-medium">{{ ingredient.name }}</div>
         <div class="text-sm text-gray-500">{{ ingredient.unitPrice | ars }} / {{ ingredient.unit }}</div>
       </div>
       <div class="text-right flex items-center gap-1">
         <div>
-          <div [class]="getStockClass(ingredient)" class="font-bold">
-            {{ ingredient.currentStock }} {{ ingredient.unit }}
-          </div>
+          <div [class]="getStockClass(ingredient)" class="font-bold">{{ ingredient.currentStock }} {{ ingredient.unit }}</div>
           <div class="text-xs text-gray-400">mín: {{ ingredient.minimumStock }}</div>
         </div>
-        <button
-          mat-icon-button
-          (click)="viewHistory(ingredient, $event)"
-          aria-label="Historial de precios"
-          class="text-gray-400"
-        >
-          <mat-icon style="font-size: 18px">history</mat-icon>
+        <button class="ui-icon-btn text-gray-400" (click)="viewHistory(ingredient, $event)" aria-label="Historial de precios" type="button">
+          <ui-icon name="history" [size]="18" [decorative]="true" />
         </button>
       </div>
-    </mat-card-content>
-  </mat-card>
+    </div>
+  </article>
 }
 
 @if (auth.isOwner()) {
-  <button mat-fab class="fab-bottom-right" color="primary" (click)="create()">
-    <mat-icon>add</mat-icon>
+  <button class="fab-bottom-right ui-fab" (click)="create()" type="button" aria-label="Agregar ingrediente">
+    <ui-icon name="add" [decorative]="true" />
   </button>
 }

--- a/src/app/features/ingredients/ingredients.component.scss
+++ b/src/app/features/ingredients/ingredients.component.scss
@@ -1,0 +1,3 @@
+:host {
+  display: block;
+}

--- a/src/app/features/ingredients/ingredients.component.ts
+++ b/src/app/features/ingredients/ingredients.component.ts
@@ -1,7 +1,4 @@
 import { ChangeDetectionStrategy, Component, computed, inject, signal } from '@angular/core';
-import { MatCardModule } from '@angular/material/card';
-import { MatIconModule } from '@angular/material/icon';
-import { MatButtonModule } from '@angular/material/button';
 import { NotificationService } from '../../core/services/notification.service';
 import { IngredientsStore } from '../../core/store/ingredients.store';
 import { RecipesStore } from '../../core/store/recipes.store';
@@ -11,11 +8,13 @@ import { IngredientFormComponent } from './ingredient-form.component';
 import { PriceHistoryComponent } from './price-history.component';
 import { AuthService } from '../../core/services/auth.service';
 import { DialogService } from '../../core/services/dialog.service';
+import { UiIconComponent } from '../../shared/ui/components';
 
 @Component({
   selector: 'app-ingredients',
-  imports: [MatCardModule, MatIconModule, MatButtonModule, ArsPipe],
+  imports: [ArsPipe, UiIconComponent],
   templateUrl: './ingredients.component.html',
+  styleUrl: './ingredients.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class IngredientsComponent {

--- a/src/app/features/ingredients/price-history.component.html
+++ b/src/app/features/ingredients/price-history.component.html
@@ -2,7 +2,7 @@
 
 @if (history().length === 0) {
   <div class="text-center py-6 text-gray-400">
-    <mat-icon style="font-size: 40px; width: 40px; height: 40px">history</mat-icon>
+    <ui-icon name="history" [size]="40" [decorative]="true" />
     <p>No hay cambios de precio registrados</p>
   </div>
 } @else {
@@ -17,5 +17,5 @@
 }
 
 <div class="flex justify-end mt-4">
-  <button mat-button type="button" (click)="close()">Cerrar</button>
+  <button class="ui-btn" type="button" (click)="close()">Cerrar</button>
 </div>

--- a/src/app/features/ingredients/price-history.component.ts
+++ b/src/app/features/ingredients/price-history.component.ts
@@ -1,12 +1,11 @@
 import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
-import { MatIconModule } from '@angular/material/icon';
-import { MatButtonModule } from '@angular/material/button';
 import { DatePipe } from '@angular/common';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { IngredientsStore } from '../../core/store/ingredients.store';
 import { ArsPipe } from '../../shared/pipes/ars.pipe';
 import { DIALOG_DATA, DIALOG_REF } from '../../core/models/dialog/dialog-tokens.model';
 import { DialogRef } from '../../core/models/dialog/dialog-ref.model';
+import { UiIconComponent } from '../../shared/ui/components';
 
 interface PriceHistoryDialogData {
   id: string;
@@ -15,7 +14,7 @@ interface PriceHistoryDialogData {
 
 @Component({
   selector: 'app-price-history',
-  imports: [MatIconModule, MatButtonModule, DatePipe, ArsPipe],
+  imports: [DatePipe, ArsPipe, UiIconComponent],
   templateUrl: './price-history.component.html',
   styleUrl: './price-history.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/src/app/features/login/login.component.html
+++ b/src/app/features/login/login.component.html
@@ -5,15 +5,15 @@
     <p class="text-gray-500 mt-2">Gestión de pastelería</p>
   </div>
 
-  <mat-card class="login-card">
-    <mat-card-content class="py-6 text-center">
+  <section class="login-card ui-card-surface">
+    <div class="py-6 text-center">
       @if (loading) {
-        <mat-spinner diameter="40" class="mx-auto mb-4"></mat-spinner>
+        <div class="ui-spinner mx-auto mb-4" aria-label="Cargando"></div>
         <p class="text-gray-500">Iniciando sesión...</p>
       } @else {
         <p class="text-gray-600 mb-6">Iniciá sesión para continuar</p>
 
-        <button mat-flat-button class="google-btn w-full" (click)="loginGoogle()">
+        <button class="ui-btn ui-btn-primary google-btn w-full" (click)="loginGoogle()" type="button">
           <img
             src="https://www.gstatic.com/firebasejs/ui/2.0.0/images/auth/google.svg"
             alt=""
@@ -28,6 +28,6 @@
           <p class="text-red-500 text-sm mt-4">{{ error }}</p>
         }
       }
-    </mat-card-content>
-  </mat-card>
+    </div>
+  </section>
 </div>

--- a/src/app/features/login/login.component.ts
+++ b/src/app/features/login/login.component.ts
@@ -1,16 +1,13 @@
-import { Component, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
 import { Router } from '@angular/router';
-import { MatButtonModule } from '@angular/material/button';
-import { MatIconModule } from '@angular/material/icon';
-import { MatCardModule } from '@angular/material/card';
-import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { AuthService } from '../../core/services/auth.service';
 
 @Component({
   selector: 'app-login',
-  imports: [MatButtonModule, MatIconModule, MatCardModule, MatProgressSpinnerModule],
+  imports: [],
   templateUrl: './login.component.html',
   styleUrl: './login.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class LoginComponent {
   private auth = inject(AuthService);
@@ -19,14 +16,14 @@ export class LoginComponent {
   loading = false;
   error = '';
 
-  async loginGoogle() {
+  async loginGoogle(): Promise<void> {
     this.loading = true;
     this.error = '';
     try {
       await this.auth.loginWithGoogle();
       this.router.navigate(['/dashboard']);
-    } catch (e: any) {
-      this.error = e?.message ?? 'Error al iniciar sesión';
+    } catch (error: unknown) {
+      this.error = error instanceof Error ? error.message : 'Error al iniciar sesión';
       this.loading = false;
     }
   }

--- a/src/app/features/recipes/catalog-dialog.component.html
+++ b/src/app/features/recipes/catalog-dialog.component.html
@@ -1,11 +1,11 @@
 <div class="flex items-center justify-between mb-2">
   <h2 class="text-xl font-semibold !mb-0">Catálogo de Precios</h2>
   <div class="flex gap-1">
-    <button mat-icon-button type="button" (click)="share()" aria-label="Compartir">
-      <mat-icon>share</mat-icon>
+    <button class="ui-icon-btn" type="button" (click)="share()" aria-label="Compartir">
+      <ui-icon name="share" [decorative]="true" />
     </button>
-    <button mat-icon-button type="button" (click)="print()" aria-label="Imprimir">
-      <mat-icon>print</mat-icon>
+    <button class="ui-icon-btn" type="button" (click)="print()" aria-label="Imprimir">
+      <ui-icon name="print" [decorative]="true" />
     </button>
   </div>
 </div>
@@ -31,5 +31,5 @@
 </div>
 
 <div class="flex justify-end mt-4">
-  <button mat-button type="button" (click)="close()">Cerrar</button>
+  <button class="ui-btn" type="button" (click)="close()">Cerrar</button>
 </div>

--- a/src/app/features/recipes/catalog-dialog.component.ts
+++ b/src/app/features/recipes/catalog-dialog.component.ts
@@ -1,14 +1,13 @@
 import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
-import { MatButtonModule } from '@angular/material/button';
-import { MatIconModule } from '@angular/material/icon';
 import { RecipesStore } from '../../core/store/recipes.store';
 import { ArsPipe } from '../../shared/pipes/ars.pipe';
 import { DIALOG_REF } from '../../core/models/dialog/dialog-tokens.model';
 import { DialogRef } from '../../core/models/dialog/dialog-ref.model';
+import { UiIconComponent } from '../../shared/ui/components';
 
 @Component({
   selector: 'app-catalog-dialog',
-  imports: [MatButtonModule, MatIconModule, ArsPipe],
+  imports: [ArsPipe, UiIconComponent],
   templateUrl: './catalog-dialog.component.html',
   styleUrl: './catalog-dialog.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/src/app/features/recipes/recipes.component.html
+++ b/src/app/features/recipes/recipes.component.html
@@ -1,38 +1,40 @@
 <div class="flex items-center justify-between mb-4">
   <h2 class="text-xl font-semibold">Recetas</h2>
-  <button mat-stroked-button (click)="viewCatalog()"><mat-icon>share</mat-icon> Catálogo</button>
+  <button class="ui-btn" type="button" (click)="viewCatalog()">
+    <ui-icon name="share" [size]="18" [decorative]="true" />
+    Catálogo
+  </button>
 </div>
 
 @if (store.recipes().length === 0) {
   <div class="text-center py-8 text-gray-400">
-    <mat-icon style="font-size: 48px; width: 48px; height: 48px">menu_book</mat-icon>
+    <ui-icon name="menu_book" [size]="48" [decorative]="true" />
     <p>No hay recetas cargadas aún</p>
     <p class="text-sm">Tocá el botón + para crear la primera</p>
   </div>
 }
 
 @for (recipe of store.recipes(); track recipe.id) {
-  <mat-card class="touch-card mb-3" (click)="auth.isOwner() ? edit(recipe) : null">
-    <mat-card-content class="py-2">
+  <article class="ui-card-surface touch-card mb-3" (click)="auth.isOwner() ? edit(recipe) : null">
+    <div class="py-2">
       <div class="flex items-center justify-between mb-1">
         <div class="font-medium text-base">{{ recipe.name }}</div>
         <div class="flex items-center gap-1">
-          <mat-chip-set>
-            <mat-chip class="text-xs">{{ recipe.category }}</mat-chip>
-          </mat-chip-set>
+          <span class="ui-chip-static">{{ recipe.category }}</span>
           @if (auth.isOwner()) {
-            <button
-              mat-icon-button
-              [matMenuTriggerFor]="recipeMenu"
-              (click)="$event.stopPropagation()"
-            >
-              <mat-icon>more_vert</mat-icon>
-            </button>
-            <mat-menu #recipeMenu="matMenu">
-              <button mat-menu-item (click)="duplicate(recipe)">
-                <mat-icon>content_copy</mat-icon> Duplicar
+            <div class="relative" (click)="onMenuClick($event)">
+              <button class="ui-icon-btn" type="button" aria-label="Abrir opciones" (click)="toggleMenu(recipe.id ?? '', $event)">
+                <ui-icon name="more_vert" [decorative]="true" />
               </button>
-            </mat-menu>
+              @if (openMenuRecipeId() === (recipe.id ?? '')) {
+                <div class="ui-menu" role="menu">
+                  <button class="ui-menu-item" type="button" role="menuitem" (click)="duplicate(recipe)">
+                    <ui-icon name="content_copy" [size]="16" [decorative]="true" />
+                    Duplicar
+                  </button>
+                </div>
+              }
+            </div>
           }
         </div>
       </div>
@@ -52,15 +54,13 @@
         </div>
       </div>
 
-      <div class="text-xs text-gray-400 mt-1">
-        {{ recipe.ingredients.length }} ingredientes · rinde {{ recipe.yield }} u.
-      </div>
-    </mat-card-content>
-  </mat-card>
+      <div class="text-xs text-gray-400 mt-1">{{ recipe.ingredients.length }} ingredientes · rinde {{ recipe.yield }} u.</div>
+    </div>
+  </article>
 }
 
 @if (auth.isOwner()) {
-  <button mat-fab class="fab-bottom-right" color="primary" (click)="create()">
-    <mat-icon>add</mat-icon>
+  <button class="fab-bottom-right ui-fab" (click)="create()" type="button" aria-label="Crear receta">
+    <ui-icon name="add" [decorative]="true" />
   </button>
 }

--- a/src/app/features/recipes/recipes.component.scss
+++ b/src/app/features/recipes/recipes.component.scss
@@ -1,0 +1,3 @@
+:host {
+  display: block;
+}

--- a/src/app/features/recipes/recipes.component.ts
+++ b/src/app/features/recipes/recipes.component.ts
@@ -1,9 +1,4 @@
-import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
-import { MatCardModule } from '@angular/material/card';
-import { MatIconModule } from '@angular/material/icon';
-import { MatButtonModule } from '@angular/material/button';
-import { MatChipsModule } from '@angular/material/chips';
-import { MatMenuModule } from '@angular/material/menu';
+import { ChangeDetectionStrategy, Component, inject, signal } from '@angular/core';
 import { NotificationService } from '../../core/services/notification.service';
 import { RecipesStore } from '../../core/store/recipes.store';
 import { Recipe } from '../../core/models/recipe';
@@ -12,18 +7,25 @@ import { RecipeFormComponent } from './recipe-form.component';
 import { CatalogDialogComponent } from './catalog-dialog.component';
 import { AuthService } from '../../core/services/auth.service';
 import { DialogService } from '../../core/services/dialog.service';
+import { UiIconComponent } from '../../shared/ui/components';
 
 @Component({
   selector: 'app-recipes',
-  imports: [MatCardModule, MatIconModule, MatButtonModule, MatChipsModule, MatMenuModule, ArsPipe],
+  imports: [ArsPipe, UiIconComponent],
   templateUrl: './recipes.component.html',
+  styleUrl: './recipes.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
+  host: {
+    '(document:click)': 'openMenuRecipeId.set(null)',
+  },
 })
 export class RecipesComponent {
   readonly store = inject(RecipesStore);
   readonly auth = inject(AuthService);
   private dialog = inject(DialogService);
   private notify = inject(NotificationService);
+
+  readonly openMenuRecipeId = signal<string | null>(null);
 
   create(): void {
     const dialogRef = this.dialog.open<null, Recipe>(RecipeFormComponent, {
@@ -71,5 +73,14 @@ export class RecipesComponent {
       maxHeight: '90vh',
       data: null,
     });
+  }
+
+  toggleMenu(recipeId: string, event: Event): void {
+    event.stopPropagation();
+    this.openMenuRecipeId.update((current) => (current === recipeId ? null : recipeId));
+  }
+
+  onMenuClick(event: Event): void {
+    event.stopPropagation();
   }
 }

--- a/src/app/features/sales/sales.component.html
+++ b/src/app/features/sales/sales.component.html
@@ -1,45 +1,52 @@
 <h2 class="text-xl font-semibold mb-4">Ventas</h2>
 
-<mat-tab-group>
-  <mat-tab label="Pendientes ({{ pending().length }})">
-    @if (pending().length === 0) {
-      <div class="text-center py-8 text-gray-400">
-        <mat-icon style="font-size: 48px; width: 48px; height: 48px">check_circle</mat-icon>
-        <p>No hay pedidos pendientes</p>
-      </div>
-    }
-    @for (sale of pending(); track sale.id) {
-      <ng-container *ngTemplateOutlet="saleCard; context: { $implicit: sale }"></ng-container>
-    }
-  </mat-tab>
+<div class="ui-tabs">
+  <button class="ui-tab" [class.active]="selectedTab() === 'pending'" (click)="selectedTab.set('pending')" type="button">
+    Pendientes ({{ pending().length }})
+  </button>
+  <button class="ui-tab" [class.active]="selectedTab() === 'history'" (click)="selectedTab.set('history')" type="button">
+    Historial
+  </button>
+</div>
 
-  <mat-tab label="Historial">
-    <div class="flex gap-2 mt-3 mb-2 flex-wrap">
-      <label class="ui-field flex-1 min-w-[180px]">
-        <span>Buscar cliente / producto</span>
-        <input class="ui-input" (input)="onSearchInput($event)" [value]="searchTerm()" />
-      </label>
-      <label class="ui-field w-[200px]">
-        <span>Desde</span>
-        <input class="ui-input" type="date" (change)="onDateFromInput($event)" />
-      </label>
+@if (selectedTab() === 'pending') {
+  @if (pending().length === 0) {
+    <div class="text-center py-8 text-gray-400">
+      <ui-icon name="check_circle" [size]="48" [decorative]="true" />
+      <p>No hay pedidos pendientes</p>
     </div>
+  }
+  @for (sale of pending(); track sale.id) {
+    <ng-container *ngTemplateOutlet="saleCard; context: { $implicit: sale }"></ng-container>
+  }
+}
 
-    @if (filteredHistory().length === 0) {
-      <div class="text-center py-6 text-gray-400">
-        <p>No se encontraron ventas</p>
-      </div>
-    }
+@if (selectedTab() === 'history') {
+  <div class="flex gap-2 mt-3 mb-2 flex-wrap">
+    <label class="ui-field flex-1 min-w-[180px]">
+      <span>Buscar cliente / producto</span>
+      <input class="ui-input" (input)="onSearchInput($event)" [value]="searchTerm()" />
+    </label>
+    <label class="ui-field w-[200px]">
+      <span>Desde</span>
+      <input class="ui-input" type="date" (change)="onDateFromInput($event)" />
+    </label>
+  </div>
 
-    @for (sale of filteredHistory(); track sale.id) {
-      <ng-container *ngTemplateOutlet="saleCard; context: { $implicit: sale }"></ng-container>
-    }
-  </mat-tab>
-</mat-tab-group>
+  @if (filteredHistory().length === 0) {
+    <div class="text-center py-6 text-gray-400">
+      <p>No se encontraron ventas</p>
+    </div>
+  }
+
+  @for (sale of filteredHistory(); track sale.id) {
+    <ng-container *ngTemplateOutlet="saleCard; context: { $implicit: sale }"></ng-container>
+  }
+}
 
 <ng-template #saleCard let-sale>
-  <mat-card class="touch-card mb-3 mt-3">
-    <mat-card-content class="py-2">
+  <article class="ui-card-surface touch-card mb-3 mt-3">
+    <div class="py-2">
       <div class="flex items-center justify-between mb-1">
         <div>
           <div class="font-medium">{{ sale.customerName || 'Sin cliente' }}</div>
@@ -47,11 +54,9 @@
         </div>
         <div class="text-right">
           <div class="text-lg font-bold">{{ sale.total | ars }}</div>
-          <mat-chip-set>
-            <mat-chip [class]="getStatusClass(sale.status)" style="font-size: 11px">
-              {{ getStatusLabel(sale.status) }}
-            </mat-chip>
-          </mat-chip-set>
+          <span class="ui-chip-static" [class]="getStatusClass(sale.status)">
+            {{ getStatusLabel(sale.status) }}
+          </span>
         </div>
       </div>
 
@@ -64,23 +69,18 @@
       @if (sale.status === 'pending') {
         <div class="flex justify-end gap-2 mt-2">
           @if (sale.customerName) {
-            <button
-              mat-icon-button
-              color="primary"
-              (click)="sendWhatsApp(sale)"
-              aria-label="Enviar por WhatsApp"
-            >
-              <mat-icon>chat</mat-icon>
+            <button class="ui-icon-btn" (click)="sendWhatsApp(sale)" aria-label="Enviar por WhatsApp" type="button">
+              <ui-icon name="chat" [decorative]="true" />
             </button>
           }
-          <button mat-stroked-button color="warn" (click)="changeStatus(sale, 'cancelled')">Cancelar</button>
-          <button mat-flat-button color="primary" (click)="changeStatus(sale, 'delivered')">Entregar ✓</button>
+          <button class="ui-btn ui-btn-danger" (click)="changeStatus(sale, 'cancelled')" type="button">Cancelar</button>
+          <button class="ui-btn ui-btn-primary" (click)="changeStatus(sale, 'delivered')" type="button">Entregar ✓</button>
         </div>
       }
-    </mat-card-content>
-  </mat-card>
+    </div>
+  </article>
 </ng-template>
 
-<button mat-fab class="fab-bottom-right" color="primary" (click)="newSale()">
-  <mat-icon>add</mat-icon>
+<button class="fab-bottom-right ui-fab" (click)="newSale()" type="button" aria-label="Nueva venta">
+  <ui-icon name="add" [decorative]="true" />
 </button>

--- a/src/app/features/sales/sales.component.scss
+++ b/src/app/features/sales/sales.component.scss
@@ -1,0 +1,3 @@
+:host {
+  display: block;
+}

--- a/src/app/features/sales/sales.component.ts
+++ b/src/app/features/sales/sales.component.ts
@@ -1,10 +1,5 @@
-import { ChangeDetectionStrategy, Component, inject, computed, signal } from '@angular/core';
-import { NgTemplateOutlet, DatePipe } from '@angular/common';
-import { MatCardModule } from '@angular/material/card';
-import { MatIconModule } from '@angular/material/icon';
-import { MatButtonModule } from '@angular/material/button';
-import { MatChipsModule } from '@angular/material/chips';
-import { MatTabsModule } from '@angular/material/tabs';
+import { ChangeDetectionStrategy, Component, computed, inject, signal } from '@angular/core';
+import { DatePipe, NgTemplateOutlet } from '@angular/common';
 import { NotificationService } from '../../core/services/notification.service';
 import { SalesStore } from '../../core/store/sales.store';
 import { CustomersStore } from '../../core/store/customers.store';
@@ -15,11 +10,13 @@ import { Sale, SALE_STATUS_DISPLAY } from '../../core/models/sale';
 import { ArsPipe } from '../../shared/pipes/ars.pipe';
 import { SaleFormComponent } from './sale-form.component';
 import { DialogService } from '../../core/services/dialog.service';
+import { UiIconComponent } from '../../shared/ui/components';
 
 @Component({
   selector: 'app-sales',
-  imports: [NgTemplateOutlet, DatePipe, MatCardModule, MatIconModule, MatButtonModule, MatChipsModule, MatTabsModule, ArsPipe],
+  imports: [NgTemplateOutlet, DatePipe, ArsPipe, UiIconComponent],
   templateUrl: './sales.component.html',
+  styleUrl: './sales.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class SalesComponent {
@@ -29,8 +26,8 @@ export class SalesComponent {
   private dialog = inject(DialogService);
   private notify = inject(NotificationService);
 
+  readonly selectedTab = signal<'pending' | 'history'>('pending');
   statusDisplay: Record<SaleStatus, string> = SALE_STATUS_DISPLAY;
-
   pending = this.store.pendingOrders;
 
   searchTerm = signal('');

--- a/src/app/features/stock/stock.component.html
+++ b/src/app/features/stock/stock.component.html
@@ -1,58 +1,54 @@
 <div class="flex items-center justify-between mb-4">
   <h2 class="text-xl font-semibold">Stock de Ingredientes</h2>
-  <a mat-stroked-button routerLink="/ingredientes"> <mat-icon>list</mat-icon> Ver todos </a>
+  <a class="ui-btn" routerLink="/ingredientes">
+    <ui-icon name="list" [size]="18" [decorative]="true" />
+    Ver todos
+  </a>
 </div>
 
 @if (store.lowStock().length > 0) {
   <div class="mb-4 p-3 bg-red-50 rounded-lg">
-    <div class="text-sm font-medium text-red-700 mb-1">
-      <mat-icon class="align-middle" style="font-size: 18px">warning</mat-icon>
+    <div class="text-sm font-medium text-red-700 mb-1 flex items-center gap-1">
+      <ui-icon name="warning" [size]="18" [decorative]="true" />
       {{ store.lowStock().length }} ingrediente(s) con stock bajo
     </div>
   </div>
 }
 
 @for (item of sortedIngredients(); track item.id) {
-  <mat-card class="touch-card mb-3" (click)="auth.isOwner() ? edit(item) : null">
-    <mat-card-content class="py-2">
+  <article class="ui-card-surface touch-card mb-3" (click)="auth.isOwner() ? edit(item) : null">
+    <div class="py-2">
       <div class="flex items-center justify-between mb-1">
         <div>
           <div class="font-medium">{{ item.name }}</div>
           <div class="text-xs text-gray-500">{{ item.category }}</div>
         </div>
         <div class="text-right">
-          <div [class]="getStockClass(item)" class="text-lg font-bold">
-            {{ item.currentStock }}
-          </div>
+          <div [class]="getStockClass(item)" class="text-lg font-bold">{{ item.currentStock }}</div>
           <div class="text-xs text-gray-400">{{ item.unit }}</div>
         </div>
       </div>
 
-      <mat-progress-bar
-        [mode]="'determinate'"
-        [value]="getStockPercent(item)"
-        [color]="getStockBarColor(item)"
-      >
-      </mat-progress-bar>
+      <div class="ui-progress"><div class="ui-progress__bar" [class]="getStockBarClass(item)" [style.width.%]="getStockPercent(item)"></div></div>
 
       <div class="flex justify-between text-xs text-gray-400 mt-1">
         <span>Mínimo: {{ item.minimumStock }} {{ item.unit }}</span>
         <span [class]="getStockClass(item)">{{ getStockLabel(item) }}</span>
       </div>
-    </mat-card-content>
-  </mat-card>
+    </div>
+  </article>
 }
 
 @if (sortedIngredients().length === 0) {
   <div class="text-center py-8 text-gray-400">
-    <mat-icon style="font-size: 48px; width: 48px; height: 48px">inventory_2</mat-icon>
+    <ui-icon name="inventory_2" [size]="48" [decorative]="true" />
     <p>No hay ingredientes cargados aún</p>
     <p class="text-sm">Tocá el botón + para agregar el primero</p>
   </div>
 }
 
 @if (auth.isOwner()) {
-  <button mat-fab class="fab-bottom-right" color="primary" (click)="create()">
-    <mat-icon>add</mat-icon>
+  <button class="fab-bottom-right ui-fab" (click)="create()" type="button" aria-label="Agregar ingrediente">
+    <ui-icon name="add" [decorative]="true" />
   </button>
 }

--- a/src/app/features/stock/stock.component.scss
+++ b/src/app/features/stock/stock.component.scss
@@ -1,0 +1,3 @@
+:host {
+  display: block;
+}

--- a/src/app/features/stock/stock.component.ts
+++ b/src/app/features/stock/stock.component.ts
@@ -1,36 +1,25 @@
 import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
-import { MatCardModule } from '@angular/material/card';
-import { MatIconModule } from '@angular/material/icon';
-import { MatButtonModule } from '@angular/material/button';
-import { MatProgressBarModule } from '@angular/material/progress-bar';
-import { MatListModule } from '@angular/material/list';
-import { MatDialog, MatDialogModule } from '@angular/material/dialog';
-import { NotificationService } from '../../core/services/notification.service';
 import { RouterLink } from '@angular/router';
+import { NotificationService } from '../../core/services/notification.service';
 import { IngredientsStore } from '../../core/store/ingredients.store';
 import { Ingredient } from '../../core/models/ingredient';
 import { getStockPriority } from '../../core/utils/stock.utils';
 import { IngredientFormComponent } from '../ingredients/ingredient-form.component';
 import { AuthService } from '../../core/services/auth.service';
+import { DialogService } from '../../core/services/dialog.service';
+import { UiIconComponent } from '../../shared/ui/components';
 
 @Component({
   selector: 'app-stock',
-  imports: [
-    MatCardModule,
-    MatIconModule,
-    MatButtonModule,
-    MatProgressBarModule,
-    MatListModule,
-    MatDialogModule,
-    RouterLink,
-  ],
+  imports: [RouterLink, UiIconComponent],
   templateUrl: './stock.component.html',
+  styleUrl: './stock.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class StockComponent {
   readonly store = inject(IngredientsStore);
   readonly auth = inject(AuthService);
-  private dialog = inject(MatDialog);
+  private dialog = inject(DialogService);
   private notify = inject(NotificationService);
 
   sortedIngredients = this.store.ingredientsSortedByStock;
@@ -63,25 +52,24 @@ export class StockComponent {
     return Math.min(percent, 100);
   }
 
-  getStockBarColor(item: Ingredient): 'primary' | 'accent' | 'warn' {
+  getStockBarClass(item: Ingredient): string {
     switch (getStockPriority(item)) {
       case 0:
-        return 'warn';
+        return 'bg-red-500';
       case 1:
-        return 'accent';
+        return 'bg-orange-400';
       default:
-        return 'primary';
+        return 'bg-green-500';
     }
   }
 
-  create() {
-    const dialogRef = this.dialog.open(IngredientFormComponent, {
-      width: '100%',
+  create(): void {
+    const dialogRef = this.dialog.open<null, Ingredient>(IngredientFormComponent, {
       maxWidth: '500px',
       data: null,
     });
 
-    dialogRef.afterClosed().subscribe(async (result: Ingredient | undefined) => {
+    dialogRef.afterClosed.subscribe(async (result) => {
       if (result) {
         await this.store.createIngredient(result);
         this.notify.success('Ingrediente creado');
@@ -89,14 +77,13 @@ export class StockComponent {
     });
   }
 
-  edit(ingredient: Ingredient) {
-    const dialogRef = this.dialog.open(IngredientFormComponent, {
-      width: '100%',
+  edit(ingredient: Ingredient): void {
+    const dialogRef = this.dialog.open<Ingredient, Ingredient | 'delete'>(IngredientFormComponent, {
       maxWidth: '500px',
       data: ingredient,
     });
 
-    dialogRef.afterClosed().subscribe(async (result: Ingredient | 'delete' | undefined) => {
+    dialogRef.afterClosed.subscribe(async (result) => {
       if (result === 'delete') {
         await this.store.deleteIngredient(ingredient.id!);
         this.notify.success('Ingrediente eliminado');

--- a/src/app/shared/layout/layout.component.html
+++ b/src/app/shared/layout/layout.component.html
@@ -1,71 +1,70 @@
-<mat-toolbar color="primary" class="top-toolbar">
+<header class="top-toolbar">
   <span class="text-lg font-medium flex-1">🧁 Lucis Gestión</span>
 
-  <button mat-icon-button [matMenuTriggerFor]="userMenu">
-    @if (auth.appUser()?.photoURL) {
-      <img
-        [src]="auth.appUser()!.photoURL"
-        [alt]="auth.appUser()!.displayName"
-        class="avatar"
-        referrerpolicy="no-referrer"
-      />
-    } @else {
-      <mat-icon>account_circle</mat-icon>
-    }
-  </button>
-  <mat-menu #userMenu="matMenu">
-    <div class="px-4 py-2 border-b">
-      <div class="font-medium">{{ auth.appUser()?.displayName }}</div>
-      <div class="text-xs text-gray-500">{{ auth.appUser()?.email }}</div>
-      <div class="text-xs mt-1">
-        <span
-          class="inline-block px-2 py-0.5 rounded-full text-white"
-          [class]="auth.isOwner() ? 'bg-rose-500' : 'bg-blue-500'"
-        >
-          {{ auth.isOwner() ? 'Dueña' : 'Ayudante' }}
-        </span>
-      </div>
-    </div>
-    <button mat-menu-item (click)="logout()">
-      <mat-icon>logout</mat-icon>
-      <span>Cerrar sesión</span>
+  <div class="relative" (click)="onMenuClick($event)">
+    <button class="ui-icon-btn" type="button" aria-haspopup="menu" [attr.aria-expanded]="menuOpen()" (click)="toggleMenu($event)">
+      @if (auth.appUser()?.photoURL) {
+        <img
+          [src]="auth.appUser()!.photoURL"
+          [alt]="auth.appUser()!.displayName"
+          class="avatar"
+          referrerpolicy="no-referrer"
+        />
+      } @else {
+        <ui-icon name="account_circle" [decorative]="true" />
+      }
     </button>
-  </mat-menu>
-</mat-toolbar>
+
+    @if (menuOpen()) {
+      <div class="ui-menu" role="menu">
+        <div class="px-4 py-2 border-b">
+          <div class="font-medium">{{ auth.appUser()?.displayName }}</div>
+          <div class="text-xs text-gray-500">{{ auth.appUser()?.email }}</div>
+          <div class="text-xs mt-1">
+            <span class="inline-block px-2 py-0.5 rounded-full text-white" [class]="auth.isOwner() ? 'bg-rose-500' : 'bg-blue-500'">
+              {{ auth.isOwner() ? 'Dueña' : 'Ayudante' }}
+            </span>
+          </div>
+        </div>
+        <button class="ui-menu-item" type="button" role="menuitem" (click)="logout()">
+          <ui-icon name="logout" [decorative]="true" [size]="18" />
+          <span>Cerrar sesión</span>
+        </button>
+      </div>
+    }
+  </div>
+</header>
 
 <main class="page-container">
   <router-outlet />
 </main>
 
 <nav class="bottom-nav">
-  <a routerLink="/dashboard" routerLinkActive="active" class="nav-item">
-    <mat-icon>home</mat-icon>
+  <a routerLink="/dashboard" routerLinkActive="active" class="nav-item ui-nav-item">
+    <ui-icon name="home" [decorative]="true" [size]="20" />
     <span>Inicio</span>
   </a>
-  <a routerLink="/recetas" routerLinkActive="active" class="nav-item">
-    <mat-icon>menu_book</mat-icon>
+  <a routerLink="/recetas" routerLinkActive="active" class="nav-item ui-nav-item">
+    <ui-icon name="menu_book" [decorative]="true" [size]="20" />
     <span>Recetas</span>
   </a>
-  <a routerLink="/costos" routerLinkActive="active" class="nav-item">
-    <mat-icon>receipt_long</mat-icon>
+  <a routerLink="/costos" routerLinkActive="active" class="nav-item ui-nav-item">
+    <ui-icon name="receipt_long" [decorative]="true" [size]="20" />
     <span>Costos</span>
   </a>
-  <a routerLink="/ventas" routerLinkActive="active" class="nav-item">
-    <mat-icon>point_of_sale</mat-icon>
+  <a routerLink="/ventas" routerLinkActive="active" class="nav-item ui-nav-item">
+    <ui-icon name="point_of_sale" [decorative]="true" [size]="20" />
     <span>Ventas</span>
   </a>
-  <a routerLink="/stock" routerLinkActive="active" class="nav-item">
-    <mat-icon
-      [matBadge]="lowStockCount() > 0 ? lowStockCount() : null"
-      matBadgeColor="warn"
-      matBadgeSize="small"
-    >
-      inventory_2
-    </mat-icon>
+  <a routerLink="/stock" routerLinkActive="active" class="nav-item ui-nav-item nav-item--badge">
+    <ui-icon name="inventory_2" [decorative]="true" [size]="20" />
+    @if (lowStockCount() > 0) {
+      <span class="badge" aria-label="{{ lowStockCount() }} ingredientes con stock bajo">{{ lowStockCount() }}</span>
+    }
     <span>Stock</span>
   </a>
-  <a routerLink="/clientes" routerLinkActive="active" class="nav-item">
-    <mat-icon>people</mat-icon>
+  <a routerLink="/clientes" routerLinkActive="active" class="nav-item ui-nav-item">
+    <ui-icon name="people" [decorative]="true" [size]="20" />
     <span>Clientes</span>
   </a>
 </nav>

--- a/src/app/shared/layout/layout.component.scss
+++ b/src/app/shared/layout/layout.component.scss
@@ -4,6 +4,12 @@
   left: 0;
   right: 0;
   z-index: var(--z-nav);
+  height: var(--size-nav-height);
+  background: var(--color-primary);
+  color: var(--color-surface);
+  display: flex;
+  align-items: center;
+  padding: 0 var(--space-4);
 }
 
 main {
@@ -41,6 +47,26 @@ main {
     color: var(--color-primary);
     font-weight: 500;
   }
+}
+
+.nav-item--badge {
+  position: relative;
+}
+
+.badge {
+  position: absolute;
+  top: 0;
+  right: var(--space-1);
+  min-width: var(--space-4);
+  height: var(--space-4);
+  border-radius: var(--radius-chip);
+  background: var(--color-status-danger);
+  color: var(--color-surface);
+  font-size: var(--size-font-2xs);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 var(--space-1);
 }
 
 .avatar {

--- a/src/app/shared/layout/layout.component.ts
+++ b/src/app/shared/layout/layout.component.ts
@@ -1,36 +1,40 @@
-import { Component, inject } from '@angular/core';
-import { MatToolbarModule } from '@angular/material/toolbar';
-import { MatIconModule } from '@angular/material/icon';
-import { MatButtonModule } from '@angular/material/button';
-import { MatBadgeModule } from '@angular/material/badge';
-import { MatMenuModule } from '@angular/material/menu';
-import { Router, RouterOutlet, RouterLink, RouterLinkActive } from '@angular/router';
+import { Component, inject, signal } from '@angular/core';
+import { Router, RouterLink, RouterLinkActive, RouterOutlet } from '@angular/router';
 import { IngredientsStore } from '../../core/store/ingredients.store';
 import { AuthService } from '../../core/services/auth.service';
+import { UiIconComponent } from '../ui/components';
 
 @Component({
   selector: 'app-layout',
-  imports: [
-    RouterOutlet,
-    RouterLink,
-    RouterLinkActive,
-    MatToolbarModule,
-    MatIconModule,
-    MatButtonModule,
-    MatBadgeModule,
-    MatMenuModule,
-  ],
+  imports: [RouterOutlet, RouterLink, RouterLinkActive, UiIconComponent],
   templateUrl: './layout.component.html',
   styleUrl: './layout.component.scss',
+  host: {
+    '(document:click)': 'closeMenu()',
+  },
 })
 export class LayoutComponent {
   private ingredientsStore = inject(IngredientsStore);
   readonly auth = inject(AuthService);
   private router = inject(Router);
 
-  lowStockCount = this.ingredientsStore.lowStockCount;
+  readonly menuOpen = signal(false);
+  readonly lowStockCount = this.ingredientsStore.lowStockCount;
 
-  async logout() {
+  closeMenu(): void {
+    this.menuOpen.set(false);
+  }
+
+  toggleMenu(event: Event): void {
+    event.stopPropagation();
+    this.menuOpen.update((value) => !value);
+  }
+
+  onMenuClick(event: Event): void {
+    event.stopPropagation();
+  }
+
+  async logout(): Promise<void> {
     await this.auth.logout();
     this.router.navigate(['/login']);
   }

--- a/src/app/shared/ui/components/index.ts
+++ b/src/app/shared/ui/components/index.ts
@@ -5,3 +5,5 @@ export { UiInputComponent } from './ui-input/ui-input.component';
 export { UiModalComponent } from './ui-modal/ui-modal.component';
 export { UiSelectComponent } from './ui-select/ui-select.component';
 export { UiToastComponent } from './ui-toast/ui-toast.component';
+
+export { UiIconComponent } from './ui-icon/ui-icon.component';

--- a/src/app/shared/ui/components/ui-icon/ui-icon.component.html
+++ b/src/app/shared/ui/components/ui-icon/ui-icon.component.html
@@ -1,0 +1,16 @@
+<svg
+  class="ui-icon"
+  [attr.width]="size()"
+  [attr.height]="size()"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+  [attr.aria-hidden]="decorative()"
+  [attr.aria-label]="label()"
+  [attr.role]="decorative() ? 'presentation' : 'img'"
+>
+  <use [attr.href]="'/icons.svg#' + name()"></use>
+</svg>

--- a/src/app/shared/ui/components/ui-icon/ui-icon.component.scss
+++ b/src/app/shared/ui/components/ui-icon/ui-icon.component.scss
@@ -1,0 +1,5 @@
+.ui-icon {
+  display: inline-block;
+  flex-shrink: 0;
+  vertical-align: middle;
+}

--- a/src/app/shared/ui/components/ui-icon/ui-icon.component.ts
+++ b/src/app/shared/ui/components/ui-icon/ui-icon.component.ts
@@ -1,0 +1,14 @@
+import { ChangeDetectionStrategy, Component, input } from '@angular/core';
+
+@Component({
+  selector: 'ui-icon',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  templateUrl: './ui-icon.component.html',
+  styleUrl: './ui-icon.component.scss',
+})
+export class UiIconComponent {
+  readonly name = input.required<string>();
+  readonly size = input(24);
+  readonly decorative = input(false);
+  readonly label = input<string | null>(null);
+}

--- a/src/index.html
+++ b/src/index.html
@@ -14,7 +14,6 @@
       href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500&display=swap"
       rel="stylesheet"
     />
-    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet" />
     <link rel="manifest" href="manifest.webmanifest" />
   </head>
   <body>

--- a/src/styles/_tokens.scss
+++ b/src/styles/_tokens.scss
@@ -50,6 +50,11 @@
   --size-font-2xs:            12px;    // Compact nav/support text size
   --size-dialog-content-max-height: 80vh; // Recipe dialog max content height
   --size-viewport-height:     100vh;   // Full viewport-height sections
+  --size-icon-button:         var(--space-8);
+  --size-fab:                 calc(var(--space-8) + var(--space-6));
+  --size-spinner:             calc(var(--space-8) + var(--space-2));
+  --size-progress-height:     var(--space-2);
+
 
   // ── Z-index scale ────────────────────────────────────────────────────────────
   --z-toast: 9999;  // Toast notifications (must be above dialogs)
@@ -70,6 +75,7 @@
   // ── Border sizes ─────────────────────────────────────────────────────────────
   --border-width-thin: 1px;
   --border-width-medium: 2px;
+  --border-width-thick:  3px;
 
   // ── Typography ───────────────────────────────────────────────────────────────
   --font-body: 400 0.875rem/1.25rem Roboto, sans-serif;

--- a/src/styles/_utilities.scss
+++ b/src/styles/_utilities.scss
@@ -4,14 +4,10 @@
 // Reusable presentational helpers that are applied across multiple components.
 // =============================================================================
 
-// ── Stock semaphore ─────────────────────────────────────────────────────────
-// Applied to stock-level indicators to communicate quantity status at a glance.
-.stock-ok      { color: var(--color-status-ok); }
+.stock-ok { color: var(--color-status-ok); }
 .stock-warning { color: var(--color-status-warning); }
-.stock-danger  { color: var(--color-status-danger); }
+.stock-danger { color: var(--color-status-danger); }
 
-// ── Touch-friendly interactive card ─────────────────────────────────────────
-// Adds tap feedback for clickable cards on touch devices.
 .touch-card {
   cursor: pointer;
   transition: box-shadow var(--transition-standard);
@@ -20,7 +16,6 @@
     box-shadow: var(--shadow-pressed);
   }
 }
-
 
 .ui-field {
   display: flex;
@@ -49,7 +44,6 @@
   border-color: var(--color-primary);
 }
 
-
 .ui-btn {
   border: var(--border-width-thin) solid var(--color-outline-variant);
   border-radius: var(--space-2);
@@ -57,6 +51,21 @@
   background: var(--color-surface-container);
   color: var(--color-on-surface);
   cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-2);
+}
+
+.ui-btn:focus-visible,
+.ui-icon-btn:focus-visible,
+.ui-fab:focus-visible,
+.ui-nav-item:focus-visible,
+.ui-menu-item:focus-visible,
+.ui-tab:focus-visible,
+.ui-toggle:focus-visible {
+  outline: var(--border-width-medium) solid var(--color-primary);
+  outline-offset: var(--space-1);
 }
 
 .ui-btn-primary {
@@ -71,7 +80,166 @@
   color: var(--color-status-danger);
 }
 
-.ui-btn:disabled {
+.ui-btn:disabled,
+.ui-icon-btn:disabled,
+.ui-fab:disabled {
   opacity: 0.5;
   cursor: not-allowed;
+}
+
+.ui-icon-btn {
+  border: var(--border-width-thin) solid transparent;
+  background: transparent;
+  color: var(--color-on-surface-variant);
+  border-radius: var(--radius-chip);
+  width: var(--size-icon-button);
+  height: var(--size-icon-button);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}
+
+.ui-icon-btn:hover {
+  background: var(--color-surface-container);
+}
+
+.ui-card-surface {
+  background: var(--color-surface);
+  border: var(--border-width-thin) solid var(--color-outline-variant);
+  border-radius: var(--space-3);
+  padding: var(--space-3);
+}
+
+.ui-chip-static {
+  display: inline-flex;
+  align-items: center;
+  border: var(--border-width-thin) solid var(--color-outline-variant);
+  border-radius: var(--radius-chip);
+  padding: var(--space-1) var(--space-2);
+  font-size: var(--size-font-2xs);
+  background: var(--color-surface-container);
+}
+
+.ui-tabs {
+  display: flex;
+  border-bottom: var(--border-width-thin) solid var(--color-outline-variant);
+  gap: var(--space-2);
+}
+
+.ui-tab {
+  border: none;
+  border-bottom: var(--border-width-medium) solid transparent;
+  background: transparent;
+  padding: var(--space-2) var(--space-3);
+  cursor: pointer;
+  color: var(--color-on-surface-variant);
+}
+
+.ui-tab.active {
+  border-bottom-color: var(--color-primary);
+  color: var(--color-primary);
+  font-weight: 600;
+}
+
+.ui-progress {
+  width: 100%;
+  height: var(--size-progress-height);
+  border-radius: var(--radius-chip);
+  overflow: hidden;
+  background: var(--color-surface-container);
+}
+
+.ui-progress__bar {
+  height: 100%;
+  transition: width var(--transition-standard);
+}
+
+.ui-spinner {
+  width: var(--size-spinner);
+  height: var(--size-spinner);
+  border-radius: 9999px;
+  border: var(--border-width-thick) solid var(--color-outline-variant);
+  border-top-color: var(--color-primary);
+  animation: spin 0.8s linear infinite;
+}
+
+.ui-fab {
+  width: var(--size-fab);
+  height: var(--size-fab);
+  border-radius: 9999px;
+  border: none;
+  background: var(--color-primary);
+  color: var(--color-surface);
+  box-shadow: var(--shadow-pressed);
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.ui-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.ui-list-item {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: var(--space-2);
+  align-items: start;
+}
+
+.ui-toggle-group {
+  width: 100%;
+  display: inline-flex;
+  border: var(--border-width-thin) solid var(--color-outline-variant);
+  border-radius: var(--radius-chip);
+  overflow: hidden;
+}
+
+.ui-toggle {
+  flex: 1;
+  border: none;
+  background: var(--color-surface);
+  color: var(--color-on-surface-variant);
+  padding: var(--space-2) var(--space-3);
+  cursor: pointer;
+}
+
+.ui-toggle.active {
+  background: var(--color-primary);
+  color: var(--color-surface);
+}
+
+.ui-menu {
+  position: absolute;
+  right: 0;
+  top: calc(100% + var(--space-1));
+  background: var(--color-surface);
+  border: var(--border-width-thin) solid var(--color-outline-variant);
+  border-radius: var(--space-2);
+  min-width: 180px;
+  box-shadow: var(--shadow-pressed);
+  z-index: var(--z-nav);
+}
+
+.ui-menu-item {
+  width: 100%;
+  border: none;
+  background: transparent;
+  color: var(--color-on-surface);
+  text-align: left;
+  padding: var(--space-2) var(--space-3);
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  cursor: pointer;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
 }


### PR DESCRIPTION
### Motivation
- Eliminar la dependencia de Angular Material del layout compartido y de los widgets visuales de las features para simplificar el stack y tener control total sobre el HTML/CSS y la iconografía.
- Mantener la experiencia visual y la navegación (desktop/mobile, FABs, menús y diálogos) sin regresiones y cumplir requisitos de contraste y foco.
- Reemplazar iconografía remota con un set SVG local reutilizable para evitar dependencias externas de Material Icons.

### Description
- Implementé un `UiIconComponent` y añadí un sprite SVG local en `public/icons.svg`, y cambié todas las referencias de `mat-icon` por `<ui-icon>` en layout y features migradas.
- Reemplacé los widgets visuales de Material por primitives CSS/HTML (`ui-card-surface`, `ui-chip-static`, `ui-tabs`/`ui-tab`, `ui-list`/`ui-list-item`, `ui-progress`, `ui-spinner`, `ui-btn`, `ui-icon-btn`, `ui-fab`, `ui-menu`) y amplié `src/styles/_utilities.scss` y `src/styles/_tokens.scss` con tokens y estados de foco accesibles.
- Migré el layout compartido (toolbar, user menu, bottom nav y badge) a HTML/CSS/Tailwind utilities y wiring a signals para el estado del menú, removiendo imports de Material de `src/app/shared/layout`.
- Migré las vistas principales (Dashboard, Sales, Stock, Recipes, Fixed-costs, Customers, Ingredients, Login, y diálogos como catálogo/historial) para usar las primitives y el `DialogService` en lugar de `MatDialog`, eliminando imports `@angular/material` en esos componentes.

### Testing
- Ejecuté `npm run build:mock` y la build de la configuración `mock` completó correctamente (build OK).
- Ejecuté `npm run test:mock` y los tests mock pasaron correctamente (tests OK).
- Intenté `npm run screenshot:mock` pero falló por ausencia de Playwright en este entorno; la ejecución indica que es necesario instalar Playwright/Chromium (`npm install` + `npx playwright install chromium`), y en este contenedor `npm install` quedó bloqueado por un `403` al registry, por lo que la captura automática no se generó (screenshot: FAIL).
- Verifiqué que no queden imports de `@angular/material` en el layout y en las features migradas mediante búsquedas en el código fuente (resultado: 0 referencias en las áreas objetivo).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef79a58d1c83289461f0eca1c4e18a)