### PR TITLE
Add Firestore composite indexes for ingredients, recipes, and priceHistory

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -1,4 +1,47 @@
 {
-  "indexes": [],
+  "indexes": [
+    {
+      "collectionGroup": "ingredients",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "active",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "name",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "recipes",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "active",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "name",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "priceHistory",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "ingredientId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "date",
+          "order": "DESCENDING"
+        }
+      ]
+    }
+  ],
   "fieldOverrides": []
 }


### PR DESCRIPTION
### Motivation
- Provide Firestore composite indexes to support queries that filter/sort by `active`+`name` on `ingredients` and `recipes` and by `ingredientId`+`date` on `priceHistory` for predictable performance.
- Ensure the indexes follow Firebase's expected schema (`collectionGroup`, `queryScope`, `fields`) so they can be deployed with the CLI.

### Description
- Updated `firestore.indexes.json` to include three composite indexes: `ingredients` (`active` ASC, `name` ASC), `recipes` (`active` ASC, `name` ASC), and `priceHistory` (`ingredientId` ASC, `date` DESC).
- Each index entry uses `collectionGroup`, `queryScope: "COLLECTION"`, and `fields` with `fieldPath` and `order` as required by the Firebase indexes schema.
- Left `fieldOverrides` as an empty array to preserve existing overrides structure.

### Testing
- Inspected the updated file with `nl -ba firestore.indexes.json` to verify the new index entries are present and correctly structured, which succeeded.
- Attempted to deploy with `firebase deploy --only firestore:indexes`, which failed because the Firebase CLI is not available in this environment (`firebase: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a144f17dac8832892b5b37a528bfe46)