### PR TITLE
feat: add financial insights models, service and reports view

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -56,6 +56,11 @@ export const routes: Routes = [
             (m) => m.FixedCostsComponent,
           ),
       },
+      {
+        path: 'reportes',
+        loadComponent: () =>
+          import('./features/reports/reports.component').then((m) => m.ReportsComponent),
+      },
       { path: '', redirectTo: 'dashboard', pathMatch: 'full' },
     ],
   },

--- a/src/app/core/models/financial-report/expense-anomaly.model.ts
+++ b/src/app/core/models/financial-report/expense-anomaly.model.ts
@@ -1,0 +1,10 @@
+import type { CostCategory } from '../fixed-cost/cost-category.model';
+import type { FinancialInsight } from './financial-insight.model';
+
+export interface ExpenseAnomaly extends FinancialInsight {
+  type: 'expense-anomaly';
+  category: CostCategory;
+  currentAmount: number;
+  baselineAmount: number;
+  increaseRatio: number;
+}

--- a/src/app/core/models/financial-report/financial-insight.model.ts
+++ b/src/app/core/models/financial-report/financial-insight.model.ts
@@ -1,0 +1,13 @@
+export type FinancialInsightType = 'product-opportunity' | 'expense-anomaly' | 'priority-customer';
+
+export type FinancialInsightSeverity = 'info' | 'warning' | 'critical';
+
+export interface FinancialInsight {
+  id: string;
+  type: FinancialInsightType;
+  severity: FinancialInsightSeverity;
+  title: string;
+  description: string;
+  impact: string;
+  recommendation: string;
+}

--- a/src/app/core/models/financial-report/financial-thresholds.model.ts
+++ b/src/app/core/models/financial-report/financial-thresholds.model.ts
@@ -1,0 +1,6 @@
+export interface FinancialThresholds {
+  highRotationUnits: number;
+  fixedCostIncreaseRatio: number;
+  priorityCustomerMinRevenue: number;
+  priorityCustomerMinPurchases: number;
+}

--- a/src/app/core/models/financial-report/index.ts
+++ b/src/app/core/models/financial-report/index.ts
@@ -1,0 +1,5 @@
+export * from './financial-insight.model';
+export * from './expense-anomaly.model';
+export * from './product-opportunity.model';
+export * from './priority-customer.model';
+export * from './financial-thresholds.model';

--- a/src/app/core/models/financial-report/priority-customer.model.ts
+++ b/src/app/core/models/financial-report/priority-customer.model.ts
@@ -1,0 +1,9 @@
+import type { FinancialInsight } from './financial-insight.model';
+
+export interface PriorityCustomer extends FinancialInsight {
+  type: 'priority-customer';
+  customerId: string;
+  customerName: string;
+  purchasesCount: number;
+  billedAmount: number;
+}

--- a/src/app/core/models/financial-report/product-opportunity.model.ts
+++ b/src/app/core/models/financial-report/product-opportunity.model.ts
@@ -1,0 +1,9 @@
+import type { FinancialInsight } from './financial-insight.model';
+
+export interface ProductOpportunity extends FinancialInsight {
+  type: 'product-opportunity';
+  recipeId: string;
+  recipeName: string;
+  soldUnits: number;
+  estimatedRevenue: number;
+}

--- a/src/app/core/services/financial-insights.service.ts
+++ b/src/app/core/services/financial-insights.service.ts
@@ -46,7 +46,7 @@ export class FinancialInsightsService {
     });
   });
 
-  readonly productOpportunities = computed<ProductOpportunity[]>(() => {
+  readonly productOpportunities = computed((): ProductOpportunity[] => {
     const quantitiesByRecipe = new Map<string, number>();
     for (const sale of this.salesForSelectedMonth()) {
       for (const item of sale.items) {
@@ -57,31 +57,31 @@ export class FinancialInsightsService {
 
     const ingredientCount = this.ingredientsStore.ingredients().length;
 
-    return [...quantitiesByRecipe.entries()]
-      .map(([recipeId, soldUnits]) => {
-        const recipe = this.recipesStore.recipes().find((candidate) => candidate.id === recipeId);
-        if (!recipe || soldUnits < this.thresholds.highRotationUnits) return null;
+    const opportunities: ProductOpportunity[] = [];
+    for (const [recipeId, soldUnits] of quantitiesByRecipe.entries()) {
+      const recipe = this.recipesStore.recipes().find((candidate) => candidate.id === recipeId);
+      if (!recipe || soldUnits < this.thresholds.highRotationUnits) continue;
 
-        const estimatedRevenue = soldUnits * recipe.salePrice;
-        return {
-          id: `product-opportunity-${recipeId}`,
-          type: 'product-opportunity',
-          severity: 'info',
-          recipeId,
-          recipeName: recipe.name,
-          soldUnits,
-          estimatedRevenue,
-          title: `Alta rotación: ${recipe.name}`,
-          description: `Se vendieron ${soldUnits} unidades durante el período seleccionado.`,
-          impact: `Ingresos estimados: $${estimatedRevenue.toLocaleString('es-AR')}.`,
-          recommendation: `Evalúa aumentar producción o variantes para sostener la demanda con base en ${ingredientCount} ingredientes activos.`,
-        } satisfies ProductOpportunity;
-      })
-      .filter((opportunity): opportunity is ProductOpportunity => opportunity !== null)
-      .sort((a, b) => b.soldUnits - a.soldUnits);
+      const estimatedRevenue = soldUnits * recipe.salePrice;
+      opportunities.push({
+        id: `product-opportunity-${recipeId}`,
+        type: 'product-opportunity',
+        severity: 'info',
+        recipeId,
+        recipeName: recipe.name,
+        soldUnits,
+        estimatedRevenue,
+        title: `Alta rotación: ${recipe.name}`,
+        description: `Se vendieron ${soldUnits} unidades durante el período seleccionado.`,
+        impact: `Ingresos estimados: $${estimatedRevenue.toLocaleString('es-AR')}.`,
+        recommendation: `Evalúa aumentar producción o variantes para sostener la demanda con base en ${ingredientCount} ingredientes activos.`,
+      });
+    }
+
+    return opportunities.sort((a, b) => b.soldUnits - a.soldUnits);
   });
 
-  readonly expenseAnomalies = computed<ExpenseAnomaly[]>(() => {
+  readonly expenseAnomalies = computed((): ExpenseAnomaly[] => {
     const monthKey = this.selectedMonthKey();
     const [yearText, monthText] = monthKey.split('-');
     const year = Number(yearText);
@@ -90,46 +90,46 @@ export class FinancialInsightsService {
 
     const categories: CostCategory[] = ['utilities', 'rent', 'wages', 'taxes', 'other'];
 
-    return categories
-      .map((category) => {
-        const currentAmount = currentEntries
+    const anomalies: ExpenseAnomaly[] = [];
+    for (const category of categories) {
+      const currentAmount = currentEntries
+        .filter((entry) => entry.category === category)
+        .reduce((sum, entry) => sum + entry.amount, 0);
+
+      const baselineMonths = this.previousMonths(year, month, 3);
+      const baselineTotal = baselineMonths.reduce((sum, baselineMonth) => {
+        const monthAmount = this.fixedCostsStore
+          .entriesForMonth(baselineMonth)
           .filter((entry) => entry.category === category)
-          .reduce((sum, entry) => sum + entry.amount, 0);
+          .reduce((categorySum, entry) => categorySum + entry.amount, 0);
+        return sum + monthAmount;
+      }, 0);
 
-        const baselineMonths = this.previousMonths(year, month, 3);
-        const baselineTotal = baselineMonths.reduce((sum, baselineMonth) => {
-          const monthAmount = this.fixedCostsStore
-            .entriesForMonth(baselineMonth)
-            .filter((entry) => entry.category === category)
-            .reduce((categorySum, entry) => categorySum + entry.amount, 0);
-          return sum + monthAmount;
-        }, 0);
+      const baselineAmount = baselineTotal / baselineMonths.length;
+      if (baselineAmount <= 0) continue;
 
-        const baselineAmount = baselineTotal / baselineMonths.length;
-        if (baselineAmount <= 0) return null;
+      const increaseRatio = (currentAmount - baselineAmount) / baselineAmount;
+      if (increaseRatio < this.thresholds.fixedCostIncreaseRatio) continue;
 
-        const increaseRatio = (currentAmount - baselineAmount) / baselineAmount;
-        if (increaseRatio < this.thresholds.fixedCostIncreaseRatio) return null;
+      anomalies.push({
+        id: `expense-anomaly-${category}-${monthKey}`,
+        type: 'expense-anomaly',
+        severity: increaseRatio >= 0.4 ? 'critical' : 'warning',
+        category,
+        currentAmount,
+        baselineAmount,
+        increaseRatio,
+        title: `Aumento de costos en ${category}`,
+        description: `El costo subió ${Math.round(increaseRatio * 100)}% frente al promedio de 3 meses previos.`,
+        impact: `Mes actual: $${currentAmount.toLocaleString('es-AR')} vs promedio: $${baselineAmount.toLocaleString('es-AR')}.`,
+        recommendation: 'Revisa contratos, consumo y opciones de negociación para esta categoría.',
+      });
+    }
 
-        return {
-          id: `expense-anomaly-${category}-${monthKey}`,
-          type: 'expense-anomaly',
-          severity: increaseRatio >= 0.4 ? 'critical' : 'warning',
-          category,
-          currentAmount,
-          baselineAmount,
-          increaseRatio,
-          title: `Aumento de costos en ${category}`,
-          description: `El costo subió ${Math.round(increaseRatio * 100)}% frente al promedio de 3 meses previos.`,
-          impact: `Mes actual: $${currentAmount.toLocaleString('es-AR')} vs promedio: $${baselineAmount.toLocaleString('es-AR')}.`,
-          recommendation: 'Revisa contratos, consumo y opciones de negociación para esta categoría.',
-        } satisfies ExpenseAnomaly;
-      })
-      .filter((anomaly): anomaly is ExpenseAnomaly => anomaly !== null)
-      .sort((a, b) => b.increaseRatio - a.increaseRatio);
+    return anomalies.sort((a, b) => b.increaseRatio - a.increaseRatio);
   });
 
-  readonly priorityCustomers = computed<PriorityCustomer[]>(() => {
+  readonly priorityCustomers = computed((): PriorityCustomer[] => {
     const customerSummary = new Map<string, { customerName: string; billedAmount: number; purchasesCount: number }>();
 
     for (const sale of this.salesForSelectedMonth()) {
@@ -158,8 +158,8 @@ export class FinancialInsightsService {
       )
       .map(([customerId, summary]) => ({
         id: `priority-customer-${customerId}`,
-        type: 'priority-customer',
-        severity: 'info',
+        type: 'priority-customer' as const,
+        severity: 'info' as const,
         customerId,
         customerName: summary.customerName,
         billedAmount: summary.billedAmount,

--- a/src/app/core/services/financial-insights.service.ts
+++ b/src/app/core/services/financial-insights.service.ts
@@ -1,0 +1,189 @@
+import { computed, inject, Injectable } from '@angular/core';
+import { CostCategory } from '../models/fixed-cost';
+import {
+  ExpenseAnomaly,
+  FinancialInsight,
+  FinancialThresholds,
+  PriorityCustomer,
+  ProductOpportunity,
+} from '../models/financial-report';
+import { CustomersStore } from '../store/customers.store';
+import { DashboardStore } from '../store/dashboard.store';
+import { FixedCostsStore } from '../store/fixed-costs.store';
+import { IngredientsStore } from '../store/ingredients.store';
+import { RecipesStore } from '../store/recipes.store';
+import { SalesStore } from '../store/sales.store';
+
+const FINANCIAL_THRESHOLDS: FinancialThresholds = {
+  highRotationUnits: 20,
+  fixedCostIncreaseRatio: 0.2,
+  priorityCustomerMinRevenue: 50000,
+  priorityCustomerMinPurchases: 3,
+};
+
+@Injectable({ providedIn: 'root' })
+export class FinancialInsightsService {
+  private salesStore = inject(SalesStore);
+  private fixedCostsStore = inject(FixedCostsStore);
+  private customersStore = inject(CustomersStore);
+  private recipesStore = inject(RecipesStore);
+  private ingredientsStore = inject(IngredientsStore);
+  private dashboardStore = inject(DashboardStore);
+
+  readonly thresholds = FINANCIAL_THRESHOLDS;
+  readonly selectedMonthKey = computed(() => {
+    const { year, month } = this.dashboardStore.selectedDate();
+    return `${year}-${String(month + 1).padStart(2, '0')}`;
+  });
+
+  readonly salesForSelectedMonth = computed(() => {
+    const monthKey = this.selectedMonthKey();
+    return this.salesStore.sales().filter((sale) => {
+      if (sale.status === 'cancelled') return false;
+      const saleDate = sale.date.toDate();
+      const saleMonthKey = `${saleDate.getFullYear()}-${String(saleDate.getMonth() + 1).padStart(2, '0')}`;
+      return saleMonthKey === monthKey;
+    });
+  });
+
+  readonly productOpportunities = computed<ProductOpportunity[]>(() => {
+    const quantitiesByRecipe = new Map<string, number>();
+    for (const sale of this.salesForSelectedMonth()) {
+      for (const item of sale.items) {
+        const current = quantitiesByRecipe.get(item.recipeId) ?? 0;
+        quantitiesByRecipe.set(item.recipeId, current + item.quantity);
+      }
+    }
+
+    const ingredientCount = this.ingredientsStore.ingredients().length;
+
+    return [...quantitiesByRecipe.entries()]
+      .map(([recipeId, soldUnits]) => {
+        const recipe = this.recipesStore.recipes().find((candidate) => candidate.id === recipeId);
+        if (!recipe || soldUnits < this.thresholds.highRotationUnits) return null;
+
+        const estimatedRevenue = soldUnits * recipe.salePrice;
+        return {
+          id: `product-opportunity-${recipeId}`,
+          type: 'product-opportunity',
+          severity: 'info',
+          recipeId,
+          recipeName: recipe.name,
+          soldUnits,
+          estimatedRevenue,
+          title: `Alta rotación: ${recipe.name}`,
+          description: `Se vendieron ${soldUnits} unidades durante el período seleccionado.`,
+          impact: `Ingresos estimados: $${estimatedRevenue.toLocaleString('es-AR')}.`,
+          recommendation: `Evalúa aumentar producción o variantes para sostener la demanda con base en ${ingredientCount} ingredientes activos.`,
+        } satisfies ProductOpportunity;
+      })
+      .filter((opportunity): opportunity is ProductOpportunity => opportunity !== null)
+      .sort((a, b) => b.soldUnits - a.soldUnits);
+  });
+
+  readonly expenseAnomalies = computed<ExpenseAnomaly[]>(() => {
+    const monthKey = this.selectedMonthKey();
+    const [yearText, monthText] = monthKey.split('-');
+    const year = Number(yearText);
+    const month = Number(monthText);
+    const currentEntries = this.fixedCostsStore.entriesForMonth(monthKey);
+
+    const categories: CostCategory[] = ['utilities', 'rent', 'wages', 'taxes', 'other'];
+
+    return categories
+      .map((category) => {
+        const currentAmount = currentEntries
+          .filter((entry) => entry.category === category)
+          .reduce((sum, entry) => sum + entry.amount, 0);
+
+        const baselineMonths = this.previousMonths(year, month, 3);
+        const baselineTotal = baselineMonths.reduce((sum, baselineMonth) => {
+          const monthAmount = this.fixedCostsStore
+            .entriesForMonth(baselineMonth)
+            .filter((entry) => entry.category === category)
+            .reduce((categorySum, entry) => categorySum + entry.amount, 0);
+          return sum + monthAmount;
+        }, 0);
+
+        const baselineAmount = baselineTotal / baselineMonths.length;
+        if (baselineAmount <= 0) return null;
+
+        const increaseRatio = (currentAmount - baselineAmount) / baselineAmount;
+        if (increaseRatio < this.thresholds.fixedCostIncreaseRatio) return null;
+
+        return {
+          id: `expense-anomaly-${category}-${monthKey}`,
+          type: 'expense-anomaly',
+          severity: increaseRatio >= 0.4 ? 'critical' : 'warning',
+          category,
+          currentAmount,
+          baselineAmount,
+          increaseRatio,
+          title: `Aumento de costos en ${category}`,
+          description: `El costo subió ${Math.round(increaseRatio * 100)}% frente al promedio de 3 meses previos.`,
+          impact: `Mes actual: $${currentAmount.toLocaleString('es-AR')} vs promedio: $${baselineAmount.toLocaleString('es-AR')}.`,
+          recommendation: 'Revisa contratos, consumo y opciones de negociación para esta categoría.',
+        } satisfies ExpenseAnomaly;
+      })
+      .filter((anomaly): anomaly is ExpenseAnomaly => anomaly !== null)
+      .sort((a, b) => b.increaseRatio - a.increaseRatio);
+  });
+
+  readonly priorityCustomers = computed<PriorityCustomer[]>(() => {
+    const customerSummary = new Map<string, { customerName: string; billedAmount: number; purchasesCount: number }>();
+
+    for (const sale of this.salesForSelectedMonth()) {
+      if (!sale.customerId) continue;
+      const current = customerSummary.get(sale.customerId) ?? {
+        customerName: sale.customerName,
+        billedAmount: 0,
+        purchasesCount: 0,
+      };
+      customerSummary.set(sale.customerId, {
+        customerName: current.customerName,
+        billedAmount: current.billedAmount + sale.total,
+        purchasesCount: current.purchasesCount + 1,
+      });
+    }
+
+    const existingCustomerIds = new Set(
+      this.customersStore.customers().map((customer) => customer.id).filter((id): id is string => Boolean(id)),
+    );
+
+    return [...customerSummary.entries()]
+      .filter(([customerId, summary]) =>
+        existingCustomerIds.has(customerId) &&
+        summary.billedAmount >= this.thresholds.priorityCustomerMinRevenue &&
+        summary.purchasesCount >= this.thresholds.priorityCustomerMinPurchases,
+      )
+      .map(([customerId, summary]) => ({
+        id: `priority-customer-${customerId}`,
+        type: 'priority-customer',
+        severity: 'info',
+        customerId,
+        customerName: summary.customerName,
+        billedAmount: summary.billedAmount,
+        purchasesCount: summary.purchasesCount,
+        title: `Cliente prioritario: ${summary.customerName}`,
+        description: `Realizó ${summary.purchasesCount} compras durante el período seleccionado.`,
+        impact: `Facturación acumulada: $${summary.billedAmount.toLocaleString('es-AR')}.`,
+        recommendation: 'Diseña una acción de fidelización personalizada para sostener recurrencia.',
+      }))
+      .sort((a, b) => b.billedAmount - a.billedAmount);
+  });
+
+  readonly insights = computed<FinancialInsight[]>(() => [
+    ...this.productOpportunities(),
+    ...this.expenseAnomalies(),
+    ...this.priorityCustomers(),
+  ]);
+
+  private previousMonths(year: number, month: number, count: number): string[] {
+    const out: string[] = [];
+    for (let offset = 1; offset <= count; offset += 1) {
+      const date = new Date(year, month - 1 - offset, 1);
+      out.push(`${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}`);
+    }
+    return out;
+  }
+}

--- a/src/app/features/reports/reports.component.html
+++ b/src/app/features/reports/reports.component.html
@@ -1,0 +1,47 @@
+<section class="page-container py-4">
+  <h1 class="text-xl font-semibold mb-1">Reportes financieros</h1>
+  <p class="text-sm text-gray-600 mb-4">Período analizado: {{ selectedMonthKey() }}</p>
+
+  @if (!hasInsights()) {
+    <p class="ui-card p-4">No se detectaron insights para el período seleccionado.</p>
+  }
+
+  @if (productOpportunities().length > 0) {
+    <section class="ui-card p-4 mb-4" aria-label="Oportunidades de producto">
+      <h2 class="text-lg font-medium mb-3">Oportunidades de producto</h2>
+      @for (insight of productOpportunities(); track insight.id) {
+        <article class="mb-3 last:mb-0">
+          <h3 class="font-medium">{{ insight.title }}</h3>
+          <p class="text-sm">{{ insight.description }}</p>
+          <p class="text-sm">{{ insight.impact }}</p>
+        </article>
+      }
+    </section>
+  }
+
+  @if (expenseAnomalies().length > 0) {
+    <section class="ui-card p-4 mb-4" aria-label="Alertas de gastos fijos">
+      <h2 class="text-lg font-medium mb-3">Alertas de gastos fijos</h2>
+      @for (insight of expenseAnomalies(); track insight.id) {
+        <article class="mb-3 last:mb-0">
+          <h3 class="font-medium">{{ insight.title }}</h3>
+          <p class="text-sm">{{ insight.description }}</p>
+          <p class="text-sm">{{ insight.impact }}</p>
+        </article>
+      }
+    </section>
+  }
+
+  @if (priorityCustomers().length > 0) {
+    <section class="ui-card p-4" aria-label="Clientes prioritarios">
+      <h2 class="text-lg font-medium mb-3">Clientes prioritarios</h2>
+      @for (insight of priorityCustomers(); track insight.id) {
+        <article class="mb-3 last:mb-0">
+          <h3 class="font-medium">{{ insight.customerName }}</h3>
+          <p class="text-sm">Compras: {{ insight.purchasesCount }} · Facturación: {{ insight.billedAmount | ars }}</p>
+          <p class="text-sm">{{ insight.recommendation }}</p>
+        </article>
+      }
+    </section>
+  }
+</section>

--- a/src/app/features/reports/reports.component.scss
+++ b/src/app/features/reports/reports.component.scss
@@ -1,0 +1,3 @@
+:host {
+  display: block;
+}

--- a/src/app/features/reports/reports.component.ts
+++ b/src/app/features/reports/reports.component.ts
@@ -1,0 +1,22 @@
+import { ChangeDetectionStrategy, Component, computed, inject } from '@angular/core';
+import { ArsPipe } from '../../shared/pipes/ars.pipe';
+import { FinancialInsightsService } from '../../core/services/financial-insights.service';
+
+@Component({
+  selector: 'app-reports',
+  imports: [ArsPipe],
+  templateUrl: './reports.component.html',
+  styleUrl: './reports.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class ReportsComponent {
+  private financialInsightsService = inject(FinancialInsightsService);
+
+  readonly insights = this.financialInsightsService.insights;
+  readonly productOpportunities = this.financialInsightsService.productOpportunities;
+  readonly expenseAnomalies = this.financialInsightsService.expenseAnomalies;
+  readonly priorityCustomers = this.financialInsightsService.priorityCustomers;
+  readonly selectedMonthKey = this.financialInsightsService.selectedMonthKey;
+
+  readonly hasInsights = computed(() => this.insights().length > 0);
+}

--- a/src/app/shared/bottom-nav/bottom-nav.component.html
+++ b/src/app/shared/bottom-nav/bottom-nav.component.html
@@ -11,6 +11,10 @@
     <ui-icon name="receipt_long" [decorative]="true" [size]="20" />
     <span>Costos</span>
   </a>
+  <a routerLink="/reportes" routerLinkActive="active" class="nav-item ui-nav-item">
+    <ui-icon name="insights" [decorative]="true" [size]="20" />
+    <span>Reportes</span>
+  </a>
   <a routerLink="/ventas" routerLinkActive="active" class="nav-item ui-nav-item">
     <ui-icon name="point_of_sale" [decorative]="true" [size]="20" />
     <span>Ventas</span>


### PR DESCRIPTION
### Motivation
- Provide a first-class, signal-driven financial insights subsystem to surface product opportunities, fixed-cost anomalies and priority customers for the selected period. 
- Keep UI templates simple by precomputing insights in a service using `computed()` and reusing existing stores as data sources.

### Description
- Added typed financial-report models with one file per interface under `src/app/core/models/financial-report/` and a barrel export (`financial-insight`, `product-opportunity`, `expense-anomaly`, `priority-customer`, `financial-thresholds`).
- Implemented `FinancialInsightsService` (`providedIn: 'root'`, uses `inject()`) which consumes `SalesStore`, `FixedCostsStore`, `IngredientsStore`, `CustomersStore`, `RecipesStore` and `DashboardStore`, and exposes `computed()` signals: `selectedMonthKey`, `salesForSelectedMonth`, `productOpportunities`, `expenseAnomalies`, `priorityCustomers` and `insights`.
- Implemented initial rules and typed configurable thresholds (`FINANCIAL_THRESHOLDS`) for: high-rotation product opportunities, fixed-cost increase anomalies vs 3-month baseline by `cost-category`, and priority customers by billed amount / purchase frequency.
- Added a `ReportsComponent` under `src/app/features/reports/` that consumes the service signals (template driven by precomputed `computed()` values), and integrated the feature into routing (`/reportes`) and the bottom navigation.

### Testing
- Ran linting with `npm run lint` and it passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14be69e7788328a65244ac97464b75)