### PR TITLE
Add financial reports feature with Excel export

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -56,6 +56,13 @@ export const routes: Routes = [
             (m) => m.FixedCostsComponent,
           ),
       },
+      {
+        path: 'reportes-financieros',
+        loadComponent: () =>
+          import('./features/financial-reports/financial-reports.component').then(
+            (m) => m.FinancialReportsComponent,
+          ),
+      },
       { path: '', redirectTo: 'dashboard', pathMatch: 'full' },
     ],
   },

--- a/src/app/core/models/financial-report/export-dataset-key.model.ts
+++ b/src/app/core/models/financial-report/export-dataset-key.model.ts
@@ -1,0 +1,5 @@
+export type ExportDatasetKey =
+  | 'insights'
+  | 'salesByProduct'
+  | 'expensesByCategory'
+  | 'keyCustomers';

--- a/src/app/core/models/financial-report/financial-export-request.model.ts
+++ b/src/app/core/models/financial-report/financial-export-request.model.ts
@@ -1,0 +1,6 @@
+import { ExportDatasetKey } from './export-dataset-key.model';
+
+export interface FinancialExportRequest {
+  datasets: ExportDatasetKey[];
+  period: Date;
+}

--- a/src/app/core/models/financial-report/index.ts
+++ b/src/app/core/models/financial-report/index.ts
@@ -1,0 +1,2 @@
+export * from './export-dataset-key.model';
+export * from './financial-export-request.model';

--- a/src/app/core/services/financial-export-excel.util.ts
+++ b/src/app/core/services/financial-export-excel.util.ts
@@ -1,0 +1,57 @@
+interface ExportSheet {
+  name: string;
+  rows: Record<string, string | number>[];
+}
+
+function escapeXml(value: string): string {
+  return value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&apos;');
+}
+
+function rowToXml(values: (string | number)[]): string {
+  const cells = values
+    .map((value) => {
+      if (typeof value === 'number') {
+        return `<Cell><Data ss:Type="Number">${value}</Data></Cell>`;
+      }
+      return `<Cell><Data ss:Type="String">${escapeXml(value)}</Data></Cell>`;
+    })
+    .join('');
+
+  return `<Row>${cells}</Row>`;
+}
+
+function sheetToXml(sheet: ExportSheet): string {
+  const headers = Object.keys(sheet.rows[0] ?? {});
+  const headerRow = rowToXml(headers);
+  const bodyRows = sheet.rows
+    .map((row) => headers.map((header) => row[header] ?? ''))
+    .map((values) => rowToXml(values))
+    .join('');
+
+  return `<Worksheet ss:Name="${escapeXml(sheet.name)}"><Table>${headerRow}${bodyRows}</Table></Worksheet>`;
+}
+
+export function exportSheetsAsExcelXml(sheets: ExportSheet[], fileName: string): void {
+  const workbookBody = sheets.map((sheet) => sheetToXml(sheet)).join('');
+
+  const xml = `<?xml version="1.0"?>
+<Workbook xmlns="urn:schemas-microsoft-com:office:spreadsheet"
+ xmlns:o="urn:schemas-microsoft-com:office:office"
+ xmlns:x="urn:schemas-microsoft-com:office:excel"
+ xmlns:ss="urn:schemas-microsoft-com:office:spreadsheet">
+${workbookBody}
+</Workbook>`;
+
+  const blob = new Blob([xml], { type: 'application/vnd.ms-excel;charset=utf-8;' });
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement('a');
+  anchor.href = url;
+  anchor.download = fileName;
+  anchor.click();
+  URL.revokeObjectURL(url);
+}

--- a/src/app/core/services/financial-export.service.ts
+++ b/src/app/core/services/financial-export.service.ts
@@ -1,0 +1,138 @@
+import { Injectable, inject } from '@angular/core';
+import { SalesStore } from '../store/sales.store';
+import { RecipesStore } from '../store/recipes.store';
+import { FixedCostsStore } from '../store/fixed-costs.store';
+import { CustomersStore } from '../store/customers.store';
+import type { FinancialExportRequest } from '../models/financial-report';
+
+@Injectable({ providedIn: 'root' })
+export class FinancialExportService {
+  private salesStore = inject(SalesStore);
+  private recipesStore = inject(RecipesStore);
+  private fixedCostsStore = inject(FixedCostsStore);
+  private customersStore = inject(CustomersStore);
+
+  private readonly fixedCostCategoryLabel: Record<string, string> = {
+    rent: 'Alquiler',
+    services: 'Servicios',
+    salaries: 'Sueldos',
+    taxes: 'Impuestos',
+    maintenance: 'Mantenimiento',
+    insurance: 'Seguros',
+    other: 'Otros',
+  };
+
+  async exportExcel(request: FinancialExportRequest): Promise<void> {
+    const { exportSheetsAsExcelXml } = await import('./financial-export-excel.util');
+    const sheets: { name: string; rows: Record<string, string | number>[] }[] = [];
+
+    for (const dataset of request.datasets) {
+      const rows = this.normalizeDataset(dataset, request.period);
+      if (rows.length === 0) {
+        continue;
+      }
+      sheets.push({ name: this.getSheetName(dataset), rows });
+    }
+
+    if (sheets.length === 0) {
+      return;
+    }
+
+    const year = request.period.getFullYear();
+    const month = String(request.period.getMonth() + 1).padStart(2, '0');
+    exportSheetsAsExcelXml(sheets, `reportes-financieros-${year}-${month}.xlsx`);
+  }
+
+  private normalizeDataset(dataset: FinancialExportRequest['datasets'][number], period: Date): Record<string, string | number>[] {
+    const salesInPeriod = this.salesStore.sales().filter((sale) => {
+      const saleDate = sale.date.toDate();
+      return saleDate.getFullYear() === period.getFullYear() && saleDate.getMonth() === period.getMonth();
+    });
+    const monthKey = `${period.getFullYear()}-${String(period.getMonth() + 1).padStart(2, '0')}`;
+    const periodSalesAmount = salesInPeriod.reduce((sum, sale) => sum + sale.total, 0);
+    const periodFixedCosts = this.fixedCostsStore.totalForMonth(monthKey);
+    const periodVariableCosts = salesInPeriod.reduce((sum, sale) => sum + sale.totalCost, 0);
+    const periodTotalCosts = periodVariableCosts + periodFixedCosts;
+    const periodNetProfit = periodSalesAmount - periodTotalCosts;
+
+    switch (dataset) {
+      case 'insights':
+        return [
+          { Métrica: 'Ventas del período', Valor: periodSalesAmount },
+          { Métrica: 'Costo de ventas', Valor: periodVariableCosts },
+          { Métrica: 'Costos fijos', Valor: periodFixedCosts },
+          { Métrica: 'Gastos totales', Valor: periodTotalCosts },
+          { Métrica: 'Ganancia neta', Valor: periodNetProfit },
+        ];
+      case 'salesByProduct': {
+        const recipeNames = new Map(this.recipesStore.recipes().map((recipe) => [recipe.id, recipe.name] as const));
+        const soldByRecipe = new Map<string, { producto: string; unidades: number; total: number }>();
+
+        for (const sale of salesInPeriod) {
+          for (const item of sale.items) {
+            const current = soldByRecipe.get(item.recipeId);
+            const name = recipeNames.get(item.recipeId) ?? 'Receta eliminada';
+            const subtotal = item.unitPrice * item.quantity;
+            if (current) {
+              current.unidades += item.quantity;
+              current.total += subtotal;
+            } else {
+              soldByRecipe.set(item.recipeId, { producto: name, unidades: item.quantity, total: subtotal });
+            }
+          }
+        }
+
+        return [...soldByRecipe.values()]
+          .sort((a, b) => b.unidades - a.unidades)
+          .map((item) => ({ Producto: item.producto, 'Unidades vendidas': item.unidades, 'Total vendido': item.total }));
+      }
+      case 'expensesByCategory': {
+        const byCategory = new Map<string, number>();
+
+        for (const entry of this.fixedCostsStore.entriesForMonth(monthKey)) {
+          byCategory.set(entry.category, (byCategory.get(entry.category) ?? 0) + entry.amount);
+        }
+
+        return [...byCategory.entries()].map(([category, amount]) => ({
+          Categoría: this.fixedCostCategoryLabel[category] ?? category,
+          Monto: amount,
+        }));
+      }
+      case 'keyCustomers': {
+        const customerNames = new Map(this.customersStore.customers().map((customer) => [customer.id, customer.name] as const));
+        const customers = new Map<string, { cliente: string; pedidos: number; total: number }>();
+
+        for (const sale of salesInPeriod) {
+          if (!sale.customerId) {
+            continue;
+          }
+          const current = customers.get(sale.customerId);
+          const customerName = customerNames.get(sale.customerId) ?? 'Cliente eliminado';
+          if (current) {
+            current.pedidos += 1;
+            current.total += sale.total;
+          } else {
+            customers.set(sale.customerId, { cliente: customerName, pedidos: 1, total: sale.total });
+          }
+        }
+
+        return [...customers.values()]
+          .sort((a, b) => b.total - a.total)
+          .map((item) => ({ Cliente: item.cliente, Pedidos: item.pedidos, Facturación: item.total }));
+      }
+    }
+  }
+
+  private getSheetName(dataset: FinancialExportRequest['datasets'][number]): string {
+    switch (dataset) {
+      case 'insights':
+        return 'Insights';
+      case 'salesByProduct':
+        return 'Ventas x producto';
+      case 'expensesByCategory':
+        return 'Gastos x categoría';
+      case 'keyCustomers':
+        return 'Clientes clave';
+    }
+  }
+}

--- a/src/app/features/financial-reports/financial-reports.component.html
+++ b/src/app/features/financial-reports/financial-reports.component.html
@@ -1,0 +1,49 @@
+<section class="ui-card-surface p-4">
+  <h2 class="text-xl font-semibold mb-2">Reportes financieros</h2>
+  <p class="text-sm text-gray-600 mb-4">Seleccioná datasets para exportar un Excel del período.</p>
+
+  <app-month-nav
+    class="mb-4 block"
+    [label]="periodLabel()"
+    [disableNext]="isCurrentMonth()"
+    (previous)="dashboardStore.goToPreviousMonth()"
+    (next)="dashboardStore.goToNextMonth()"
+  >
+    <label class="period-overlay" mn-overlay>
+      <span class="sr-only">Seleccionar mes del reporte</span>
+      <input
+        type="month"
+        class="period-overlay__input"
+        [value]="monthInputValue()"
+        [max]="maxMonth"
+        (change)="onMonthInputChange($event)"
+        aria-label="Período del reporte"
+      />
+    </label>
+  </app-month-nav>
+
+  <fieldset class="space-y-2" aria-describedby="export-hint">
+    <legend class="font-medium mb-2">Datasets disponibles</legend>
+    @for (option of exportOptions; track option.key) {
+      <label class="flex items-center gap-2">
+        <input
+          type="checkbox"
+          [checked]="selectedDatasets().includes(option.key)"
+          (change)="onDatasetChange($event, option.key)"
+        />
+        <span>{{ option.label }}</span>
+      </label>
+    }
+  </fieldset>
+
+  <p id="export-hint" class="text-xs text-gray-500 mt-2">Debés seleccionar al menos un dataset para habilitar la exportación.</p>
+
+  <button
+    type="button"
+    class="mt-4 ui-btn ui-btn--primary"
+    [disabled]="!isExportEnabled()"
+    (click)="export()"
+  >
+    Exportar Excel
+  </button>
+</section>

--- a/src/app/features/financial-reports/financial-reports.component.scss
+++ b/src/app/features/financial-reports/financial-reports.component.scss
@@ -1,0 +1,3 @@
+:host {
+  display: block;
+}

--- a/src/app/features/financial-reports/financial-reports.component.ts
+++ b/src/app/features/financial-reports/financial-reports.component.ts
@@ -1,0 +1,80 @@
+import { ChangeDetectionStrategy, Component, computed, inject, signal } from '@angular/core';
+import { DashboardStore } from '../../core/store/dashboard.store';
+import { FinancialExportService } from '../../core/services/financial-export.service';
+import type { ExportDatasetKey } from '../../core/models/financial-report';
+import { MonthNavComponent } from '../../shared/month-nav/month-nav.component';
+
+interface ExportOption {
+  key: ExportDatasetKey;
+  label: string;
+}
+
+@Component({
+  selector: 'app-financial-reports',
+  imports: [MonthNavComponent],
+  templateUrl: './financial-reports.component.html',
+  styleUrl: './financial-reports.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class FinancialReportsComponent {
+  readonly dashboardStore = inject(DashboardStore);
+  private readonly financialExportService = inject(FinancialExportService);
+
+  readonly periodLabel = this.dashboardStore.periodLabel;
+  readonly monthInputValue = this.dashboardStore.monthInputValue;
+  readonly isCurrentMonth = this.dashboardStore.isCurrentMonth;
+  readonly selectedDate = this.dashboardStore.selectedDate;
+
+  readonly exportOptions: ExportOption[] = [
+    { key: 'insights', label: 'Insights financieros' },
+    { key: 'salesByProduct', label: 'Ventas por producto' },
+    { key: 'expensesByCategory', label: 'Gastos por categoría' },
+    { key: 'keyCustomers', label: 'Clientes clave' },
+  ];
+
+  readonly selectedDatasets = signal<ExportDatasetKey[]>([]);
+  readonly isExportEnabled = computed(() => this.selectedDatasets().length > 0);
+  readonly maxMonth = (() => {
+    const date = new Date();
+    return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}`;
+  })();
+
+  onDatasetToggle(dataset: ExportDatasetKey, checked: boolean): void {
+    if (checked) {
+      this.selectedDatasets.update((datasets) => [...new Set([...datasets, dataset])]);
+      return;
+    }
+    this.selectedDatasets.update((datasets) => datasets.filter((item) => item !== dataset));
+  }
+
+  onDatasetChange(event: Event, dataset: ExportDatasetKey): void {
+    const target = event.target;
+    if (!(target instanceof HTMLInputElement)) {
+      return;
+    }
+    this.onDatasetToggle(dataset, target.checked);
+  }
+
+  onMonthInputChange(event: Event): void {
+    const input = event.target as HTMLInputElement;
+    const [yearText, monthText] = input.value.split('-');
+    const year = Number(yearText);
+    const month = Number(monthText);
+    if (!Number.isInteger(year) || !Number.isInteger(month) || month < 1 || month > 12) {
+      return;
+    }
+    this.dashboardStore.setSelectedDate({ year, month: month - 1 });
+  }
+
+  async export(): Promise<void> {
+    if (!this.isExportEnabled()) {
+      return;
+    }
+
+    const { year, month } = this.selectedDate();
+    await this.financialExportService.exportExcel({
+      datasets: this.selectedDatasets(),
+      period: new Date(year, month, 1),
+    });
+  }
+}


### PR DESCRIPTION
### Motivation

- Provide a new financial reports UI to select datasets and export aggregated period reports as an Excel file generated client-side.

### Description

- Add a route `reportes-financieros` and a new `FinancialReportsComponent` with template and styles to select period and datasets and trigger export. 
- Introduce models `ExportDatasetKey` and `FinancialExportRequest` under `core/models/financial-report` and re-export them from the folder index. 
- Implement `FinancialExportService` to aggregate data from `SalesStore`, `RecipesStore`, `FixedCostsStore`, and `CustomersStore`, normalizing datasets (`insights`, `salesByProduct`, `expensesByCategory`, `keyCustomers`) and naming sheets. 
- Add `financial-export-excel.util` which serializes sheets to Excel-compatible XML and triggers a download as an `.xlsx` file. 

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14c0f85b60832895966d782e3a6f92)