### PR TITLE
Prepare TFM delivery documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,78 +1,98 @@
-
 # AGENTS.md
 
 ## Purpose
 
 This file describes the repository structure, technology stack, workflow expectations, and installed agent skills for `LucisGestion`.
 
-It is not a development styleguide for Angular implementation details. Instead, it should help contributors and automation agents understand:
+It helps contributors and automation agents understand:
 
-- the project architecture
-- the main technologies in use
-- the recommended workflow for this repository
-- which skill should handle Angular-specific implementation questions
-- optional sections that improve agent guidance
+- the project architecture;
+- the main technologies in use;
+- the recommended workflow for this repository;
+- which skill should handle Angular-specific implementation questions;
+- TFM delivery documentation expectations.
 
 ## Project Architecture
 
-This repository is an Angular workspace built around a single application.
+This repository is an Angular workspace built around a single application for artisanal bakery management.
 
 Key directories:
 
-- `src/app/` — application source code
-- `src/app/features/` — feature modules and feature-related components
-- `src/app/shared/` — shared UI components, pipes, and utilities
-- `src/app/core/` — core services, models, guards, and app-wide utilities
-- `src/styles/` — design tokens, layout helpers, and reusable style utilities
-- `src/environments/` — runtime environment configuration
+- `src/app/` — application source code.
+- `src/app/features/` — feature screens and feature-specific components.
+- `src/app/shared/` — shared UI components, layout, pipes, and utilities.
+- `src/app/core/` — core services, models, guards, stores, and app-wide utilities.
+- `src/environments/` — runtime environment configuration.
+- `read first/` — deployment and manual testing documentation.
+- `docs/presentation/` — TFM slide deck source material.
+- `docs/video/` — TFM video narration script.
+- `public/images/landing/` — public visual assets used by the landing page and presentation material.
 
 Important files:
 
-- `angular.json` — workspace configuration
-- `package.json` — dependency and script definitions
-- `tsconfig.json` — TypeScript compiler settings
-- `src/main.ts` — app bootstrap
-- `src/index.html` — application shell
+- `angular.json` — workspace configuration.
+- `package.json` — dependency and script definitions.
+- `tsconfig.json` — TypeScript compiler settings.
+- `src/main.ts` — application bootstrap.
+- `src/index.html` — application shell.
+- `firebase.json` — Firebase Hosting and deployment configuration.
+- `firestore.rules` — Firestore security rules.
+- `firestore.indexes.json` — Firestore index definitions.
 
 ## Technologies
 
 This repository uses the following technology stack as declared in `package.json`:
 
-- Angular `^21.2.x`
-- Firebase / AngularFire
-- NgRx Signals for reactive state support
-- Tailwind CSS v4
-- ESLint with `angular-eslint`
-- Vitest for unit testing
-- Playwright for browser automation and visual tests
-- PNPM package manager
+- Angular `^22.0.x`.
+- Firebase / AngularFire.
+- NgRx Signals for reactive state support.
+- Tailwind CSS v4.
+- ESLint with `angular-eslint`.
+- Vitest for unit testing.
+- Playwright for screenshot and browser automation tooling.
+- PNPM package manager.
+- jsPDF, jsPDF AutoTable, and ExcelJS for report exports.
 
-The repository is a private workspace and does not use Angular Material or CDK as part of the shipped dependencies.
+The repository is a private workspace and does not use Angular Material or CDK as shipped dependencies.
+
+## Application Modes
+
+- Firebase mode: `pnpm start` runs the real Firebase-backed application.
+- Mock/demo mode: `pnpm start:mock` runs the application with in-memory data and no login requirement.
+- Public demo: `https://lucis-gestion-6cea2.web.app/demo` is the preferred TFM evaluation path.
 
 ## Workflow
 
 Primary commands:
 
-- `pnpm start` — serve the application locally
-- `pnpm test` — run test suite
-- `pnpm lint` — run lint checks
-- `pnpm build` — build the application
-- `pnpm release` — create a release package or deployment bundle
+- `pnpm install` — install dependencies.
+- `pnpm start` — serve the Firebase-backed application locally.
+- `pnpm start:mock` — serve the mock/demo application locally.
+- `pnpm test` — run the unit test suite.
+- `pnpm test:mock` — run mock-mode verification.
+- `pnpm lint` — run lint checks.
+- `pnpm build` — build the production application.
+- `pnpm build:mock` — build the mock/demo configuration.
+- `pnpm screenshot:mock` — capture a demo screenshot when Playwright browsers are installed.
+- `pnpm release` — create a release package or deployment bundle.
 
 Guidance for contributors:
 
 - Focus on the existing `src/app/` structure and keep new code within the appropriate feature or shared area.
-- Keep changes aligned with the repository's architecture rather than introducing new application-wide patterns without review.
+- Keep changes aligned with the repository architecture rather than introducing new application-wide patterns without review.
 - Use `pnpm` for installs and scripts to stay consistent with the workspace.
+- Keep TFM-facing documentation in English unless explicitly requested otherwise.
+- When changing user-visible behavior, update `README.md`, the deployment guide, and the manual test cases when relevant.
 
 ## Don'ts
 
 - No usar nombres de dos letras para inyecciones ni variables. Usa nombres descriptivos.
 - No agregar comentarios inline. El código debe ser autoexplicativo.
-- No tipar con `any`. Si se necesita un tipo, crearlo en `src/app/models/`.
+- No tipar con `any`. Si se necesita un tipo, crearlo en `src/app/core/models/`.
+- Do not introduce Angular Material or CDK unless the dependency decision is explicitly reviewed.
 
 ## Installed Skills
 
 This workspace includes an Angular-focused skill path for implementation support.
 
-- `angular-developer` — use this skill for Angular-specific development guidance and code generation.[see](.agents/skills/angular-developer)
+- `angular-developer` — use this skill for Angular-specific development guidance and code generation. See `.agents/skills/angular-developer`.

--- a/README.md
+++ b/README.md
@@ -1,83 +1,229 @@
 # Lucis Gestión
 
-Sistema de gestión para pastelería artesanal. Permite administrar ingredientes, recetas con costeo automático, ventas con control de stock, clientes y dashboard de métricas.
+Lucis Gestión is a production-ready web application for managing a small handmade bakery or pastry business. It centralizes recipes, ingredient costs, inventory, sales, customers, fixed costs, and financial indicators in a single responsive PWA.
 
-## Tech Stack
+The project was developed as a Final Master's Project (TFM) and is intended to be reviewed through the public deployment and the built-in demo mode, which allows evaluators to explore the application without creating an account or configuring Firebase.
 
-- **Angular 21** (standalone components, signals, OnPush)
-- **UI propia Tailwind CSS 4
-- **NgRx Signals** (store reactivo)
-- **Firebase** (Auth, Firestore, Hosting)
-- **PWA** (Service Worker, offline support)
+## Live Deployment
 
-## Requisitos
+- **Production URL:** <https://lucis-gestion-6cea2.web.app/>
+- **Recommended evaluator access:** <https://lucis-gestion-6cea2.web.app/demo>
+- **Demo mode credentials:** no username or password required. The demo route auto-authenticates an in-memory owner user and loads sample business data.
+- **Real login:** Google authentication is available from the production application for real Firebase-backed usage.
 
-| Herramienta | Versión mínima |
+## Project Overview
+
+Lucis Gestión solves common operational problems for an artisanal bakery:
+
+- knowing the real cost of each recipe based on ingredient prices;
+- keeping inventory up to date after sales;
+- tracking pending and delivered orders;
+- managing customers and WhatsApp communication;
+- monitoring revenue, costs, profit, low stock, best-selling products, and customer relevance;
+- exporting reports and maintaining backup/restore workflows.
+
+The application supports two execution modes:
+
+1. **Firebase mode:** real Google login, Firestore persistence, Firebase Hosting deployment, and production PWA behavior.
+2. **Demo/mock mode:** no login and no Firebase dependency; data is stored in memory and reset when the browser refreshes.
+
+## Technology Stack
+
+| Area | Technology |
 |---|---|
-| Node.js | 20+ |
-| pnpm | 10+ |
-| Angular CLI | 21+ |
+| Frontend framework | Angular 22 with standalone components |
+| State management | Angular signals and NgRx Signals |
+| Styling | Tailwind CSS 4 and custom SCSS components |
+| Backend as a service | Firebase Authentication and Cloud Firestore |
+| Hosting | Firebase Hosting |
+| PWA | Angular service worker and Web App Manifest |
+| Testing | Vitest, Angular testing utilities, jsdom, Playwright-based screenshot tooling |
+| Reports | jsPDF, jsPDF AutoTable, ExcelJS |
+| Tooling | PNPM, Angular CLI, ESLint, Prettier, TypeScript |
 
-## Instalación
+## Requirements
+
+| Tool | Minimum / expected version |
+|---|---|
+| Node.js | `>=22.22.3` |
+| pnpm | `11.1.1` or compatible |
+| Angular CLI | Angular CLI compatible with Angular 22 |
+| Firebase CLI | Required only for deployment |
+
+## Installation
 
 ```bash
 pnpm install
 ```
 
-## Comandos
+## Running the Application
 
-| Comando | Descripción |
-|---|---|
-| `pnpm start` | Servidor de desarrollo (requiere Firebase configurado) |
-| `pnpm start:mock` | **Servidor con datos de prueba** (sin Firebase, sin login) |
-| `pnpm build` | Build de producción |
-| `pnpm test` | Tests unitarios con Vitest |
-
-## Modo Mock (demo sin Firebase)
-
-Para levantar la app sin necesidad de Firebase ni conexión a internet:
+### Recommended local review: demo mode
 
 ```bash
 pnpm start:mock
 ```
 
-Esto reemplaza los servicios de Firebase por implementaciones en memoria con datos de ejemplo preconfigurados:
-- 10 ingredientes con stock y precios
-- 4 recetas con costeo calculado
-- 4 clientes
-- 5 ventas (pendientes y entregadas)
+Open <http://localhost:4200/demo>. This mode replaces Firebase services with in-memory services and starts with sample ingredients, recipes, customers, sales, fixed costs, and stock data.
 
-El usuario queda auto-logueado como "owner". Todas las operaciones CRUD funcionan en memoria (los datos se pierden al refrescar la página).
+### Firebase-backed development mode
 
-**Ideal para**: demos, evaluación de la app, pruebas de UI sin dependencias externas.
-
-## Estructura del proyecto
-
+```bash
+pnpm start
 ```
+
+Open <http://localhost:4200>. This mode requires valid Firebase configuration in `src/environments/environment.ts`.
+
+## Main Commands
+
+| Command | Description |
+|---|---|
+| `pnpm start` | Runs the Firebase-backed development server |
+| `pnpm start:mock` | Runs the app with mock data and no login requirement |
+| `pnpm build` | Builds the production application |
+| `pnpm build:mock` | Builds the mock/demo configuration |
+| `pnpm test` | Runs the unit test suite with Vitest |
+| `pnpm test:mock` | Runs the mock-mode verification script |
+| `pnpm lint` | Runs ESLint |
+| `pnpm screenshot:mock` | Starts mock mode and captures a screenshot when Playwright browsers are available |
+| `pnpm release` | Creates the release/deployment bundle |
+
+## Project Structure
+
+```text
 src/app/
 ├── core/
-│   ├── guards/         # Auth guard
-│   ├── models/         # Interfaces y tipos del dominio
-│   ├── services/       # FirestoreService, AuthService + mocks
-│   └── store/          # PasteleriaStore (NgRx Signals)
+│   ├── guards/              # Authentication, demo, guest, and owner route guards
+│   ├── models/              # Domain models for ingredients, recipes, sales, reports, users, etc.
+│   ├── services/            # Firebase services, mock services, dashboard metrics, stock, sales, notifications
+│   └── store/               # NgRx Signal stores and shared state definitions
 ├── features/
-│   ├── clientes/       # ABM de clientes
-│   ├── dashboard/      # KPIs, gráficos, alertas
-│   ├── ingredientes/   # ABM + historial de precios
-│   ├── login/          # Login con Google
-│   ├── recetas/        # ABM + costeo + catálogo
-│   ├── stock/          # Vista semáforo de stock
-│   └── ventas/         # Registro de ventas + historial
-└── shared/
-    ├── layout/         # Shell con top toolbar y bottom nav
-    └── pipes/          # Pipe ARS (formato moneda)
+│   ├── backup-restore/      # Data export/import and recovery workflows
+│   ├── customers/           # Customer CRUD and WhatsApp contact actions
+│   ├── dashboard/           # Business KPIs, period filters, and operational alerts
+│   ├── financial-reports/   # Financial insights, PDF/Excel exports, recommendations, top customers/products
+│   ├── fixed-costs/         # Monthly fixed cost registration and analysis
+│   ├── ingredients/         # Ingredient CRUD, prices, units, categories, and price history
+│   ├── landing/             # Public marketing/entry page
+│   ├── login/               # Google sign-in screen
+│   ├── recipes/             # Recipe CRUD, cost calculation, categories, catalog sharing/printing
+│   ├── sales/               # Sales registration, pending orders, history, payment methods, WhatsApp messages
+│   └── stock/               # Inventory status, low-stock indicators, and stock movements
+├── shared/
+│   ├── bottom-nav/          # Mobile-first navigation
+│   ├── layout/              # Authenticated application shell
+│   ├── pipes/               # ARS currency formatting
+│   ├── ui/                  # Reusable UI primitives
+│   └── ui-bottom-sheet/     # Bottom sheet and confirmation dialog infrastructure
+└── environments/            # Runtime environment configuration
 ```
 
-## Nota de UI
+## Main Features
 
-La UI se basa en componentes/primitivas propias y set SVG local.
+### 1. Dashboard and Business KPIs
 
-## Documentación adicional
+- Revenue, cost, net profit, and best-selling product indicators.
+- Period filters for daily, weekly, and monthly analysis.
+- Low-stock alerts connected to the inventory module.
 
-- [`read first/GUIA-DESPLIEGUE.md`](read%20first/GUIA-DESPLIEGUE.md) — Guía paso a paso para desplegar en Firebase
-- [`read first/MANUAL-CASOS-DE-PRUEBA.md`](read%20first/MANUAL-CASOS-DE-PRUEBA.md) — 30 casos de prueba funcionales
+### 2. Ingredient and Price Management
+
+- Ingredient CRUD with measurement units, categories, current stock, minimum stock, and purchase prices.
+- Price history tracking when ingredient prices change.
+- Automatic recipe cost recalculation after price changes.
+
+### 3. Recipes and Catalog
+
+- Recipe creation with ingredient quantities, yield, margin, real cost, and suggested price.
+- Recipe duplication for faster product creation.
+- Shareable and printable product catalog.
+
+### 4. Sales and Stock Control
+
+- Sales registration with one or more products.
+- Automatic ingredient stock deduction based on recipe quantities.
+- Pending, delivered, and cancelled order states.
+- WhatsApp message generation for customer communication.
+
+### 5. Customers
+
+- Customer creation, update, search, and soft delete.
+- Phone and address management.
+- Direct WhatsApp contact from customer cards.
+
+### 6. Financial Reports
+
+- Revenue, cost, and profit analysis.
+- Top products and top customers.
+- Low-stock report and recommendations.
+- PDF and Excel export support.
+
+### 7. Fixed Costs
+
+- Monthly fixed cost registration.
+- Cost categories and period-based tracking.
+- Integration with financial analysis.
+
+### 8. Backup and Restore
+
+- Data export/import workflows intended for owners.
+- Useful for operational recovery and academic demonstration of data portability.
+
+## Demo Data and Test Access
+
+For TFM review, use the demo mode:
+
+- **URL:** <https://lucis-gestion-6cea2.web.app/demo>
+- **User:** not required
+- **Password:** not required
+- **Role:** owner in demo mode
+- **Persistence:** in-memory only; changes are reset after refreshing or restarting the app
+
+The demo dataset includes representative ingredients, recipes, customers, sales, fixed costs, stock levels, and financial indicators so the evaluator can validate the core workflow without account setup.
+
+## Deployment Information
+
+The application is deployed on Firebase Hosting:
+
+```text
+https://lucis-gestion-6cea2.web.app/
+```
+
+The Firebase deployment includes:
+
+- Angular production build;
+- SPA hosting rewrite to `index.html`;
+- Firestore security rules;
+- Firestore indexes;
+- PWA assets.
+
+Detailed deployment steps are documented in [`read first/GUIA-DESPLIEGUE.md`](read%20first/GUIA-DESPLIEGUE.md).
+
+## TFM Delivery Resources
+
+| Resource | Location |
+|---|---|
+| Main documentation | [`README.md`](README.md) |
+| Deployment guide | [`read first/GUIA-DESPLIEGUE.md`](read%20first/GUIA-DESPLIEGUE.md) |
+| Manual test cases | [`read first/MANUAL-CASOS-DE-PRUEBA.md`](read%20first/MANUAL-CASOS-DE-PRUEBA.md) |
+| Slide deck content | [`docs/presentation/TFM-SLIDES.md`](docs/presentation/TFM-SLIDES.md) |
+| Video script | [`docs/video/TFM-VIDEO-SCRIPT.md`](docs/video/TFM-VIDEO-SCRIPT.md) |
+
+## Suggested Evaluation Flow
+
+1. Open <https://lucis-gestion-6cea2.web.app/demo>.
+2. Review the dashboard KPIs and low-stock alerts.
+3. Open Ingredients and review stock/prices.
+4. Open Recipes and verify calculated costs and suggested prices.
+5. Register a new sale and confirm that stock is updated.
+6. Mark the sale as delivered.
+7. Open Customers and test WhatsApp contact actions.
+8. Open Financial Reports and export a report if needed.
+9. Review the manual test cases for a structured validation path.
+
+## Additional Documentation
+
+- [`read first/GUIA-DESPLIEGUE.md`](read%20first/GUIA-DESPLIEGUE.md) — Firebase deployment and production configuration guide.
+- [`read first/MANUAL-CASOS-DE-PRUEBA.md`](read%20first/MANUAL-CASOS-DE-PRUEBA.md) — Functional test manual with expected results.
+- [`docs/presentation/TFM-SLIDES.md`](docs/presentation/TFM-SLIDES.md) — Slide-by-slide content and generation prompt.
+- [`docs/video/TFM-VIDEO-SCRIPT.md`](docs/video/TFM-VIDEO-SCRIPT.md) — Narration script for the required screen-recorded video.

--- a/docs/presentation/TFM-SLIDES.md
+++ b/docs/presentation/TFM-SLIDES.md
@@ -1,0 +1,186 @@
+# TFM Slide Deck — Lucis Gestión
+
+This document can be submitted as the slide resource or used as a source script to create Google Slides, PowerPoint, Canva, or Gamma slides.
+
+## Public Links to Include
+
+- Application: <https://lucis-gestion-6cea2.web.app/>
+- Demo: <https://lucis-gestion-6cea2.web.app/demo>
+- Documentation: `README.md`
+- Video: add the final public YouTube/Drive URL here after recording.
+
+## Visual Assets
+
+Use the existing project images as screenshots or visual references:
+
+- `public/images/landing/dashboard-preview.svg`
+- `public/images/landing/inventory-showcase.svg`
+- `public/images/landing/analytics-showcase.svg`
+- `public/images/landing/operations-showcase.svg`
+
+If you can capture live screenshots, use the demo route and include:
+
+1. Dashboard KPIs.
+2. Recipe cost screen.
+3. Sales/order flow.
+4. Stock traffic-light view.
+5. Financial reports/export screen.
+
+## Slide 1 — Title
+
+**Title:** Lucis Gestión  
+**Subtitle:** Bakery management web application for recipes, stock, sales, customers, and financial reporting  
+**Footer:** Final Master's Project — TFM
+
+**Suggested visual:** landing or dashboard preview.
+
+## Slide 2 — Problem and Motivation
+
+**Key message:** Small handmade bakery businesses often manage prices, stock, and orders manually, which creates errors and makes profitability hard to understand.
+
+**Bullets:**
+
+- Ingredient prices change frequently.
+- Recipe profitability depends on exact costs and margins.
+- Sales should automatically affect inventory.
+- Owners need simple KPIs, reports, and customer communication.
+
+## Slide 3 — Proposed Solution
+
+**Key message:** Lucis Gestión centralizes the operational cycle in a responsive PWA.
+
+**Bullets:**
+
+- Recipe costing with suggested prices.
+- Ingredient inventory with low-stock alerts.
+- Sales registration and order status tracking.
+- Customer management and WhatsApp actions.
+- Financial dashboard, reports, and exports.
+- Demo mode for evaluation without login.
+
+## Slide 4 — Target Users and Scope
+
+**Bullets:**
+
+- Primary user: owner of a small bakery or pastry business.
+- Secondary user: assistant who supports daily operations.
+- Scope: inventory, recipes, sales, customers, fixed costs, reporting, backup/restore.
+- Out of scope: online payments, marketplace checkout, and logistics integrations.
+
+## Slide 5 — Technology Stack
+
+**Bullets:**
+
+- Angular 22 with standalone components.
+- Angular signals and NgRx Signals for reactive state.
+- Firebase Authentication, Firestore, and Hosting.
+- Tailwind CSS 4 and custom UI primitives.
+- Vitest, ESLint, Playwright tooling.
+- jsPDF and ExcelJS for exports.
+
+**Suggested visual:** architecture diagram with Angular frontend, Firebase backend, and browser/PWA users.
+
+## Slide 6 — Architecture
+
+**Bullets:**
+
+- `features/`: business screens such as dashboard, ingredients, recipes, sales, reports.
+- `core/`: guards, services, stores, and domain models.
+- `shared/`: reusable layout, navigation, UI components, and pipes.
+- Firebase-backed mode for production.
+- Mock mode for demos and deterministic review.
+
+## Slide 7 — Main Workflow
+
+**Flow:**
+
+1. Create ingredients with price and stock.
+2. Build recipes using ingredient quantities.
+3. Calculate cost and suggested selling price.
+4. Register sales.
+5. Deduct stock automatically.
+6. Monitor dashboard and financial reports.
+
+**Suggested visual:** numbered process diagram.
+
+## Slide 8 — Demo Mode
+
+**Bullets:**
+
+- URL: <https://lucis-gestion-6cea2.web.app/demo>
+- No credentials required.
+- Auto-authenticated as owner.
+- Includes sample ingredients, recipes, customers, sales, stock, and costs.
+- Safe for evaluators because changes are temporary.
+
+**Suggested visual:** screenshot of dashboard in demo mode.
+
+## Slide 9 — Key Feature: Recipe Costing
+
+**Bullets:**
+
+- Recipes are composed from real ingredients.
+- Cost is calculated from current ingredient prices and quantities.
+- Margin produces a suggested sale price.
+- Price changes can recalculate affected recipes.
+
+**Suggested visual:** recipe form or recipe list.
+
+## Slide 10 — Key Feature: Sales and Stock
+
+**Bullets:**
+
+- Sales support multiple products.
+- Orders can be pending, delivered, or cancelled.
+- Confirmed sales deduct ingredient stock.
+- WhatsApp messages help communicate order details.
+
+**Suggested visual:** sales screen or order card.
+
+## Slide 11 — Key Feature: Dashboard and Reports
+
+**Bullets:**
+
+- Revenue, cost, net profit, and best-selling product.
+- Daily, weekly, and monthly period filtering.
+- Low-stock alerts.
+- Financial reports with PDF and Excel exports.
+
+**Suggested visual:** analytics showcase or financial reports screen.
+
+## Slide 12 — Deployment and Quality
+
+**Bullets:**
+
+- Deployed with Firebase Hosting.
+- Firestore rules and indexes are versioned in the repository.
+- PWA-ready application shell.
+- Functional test manual included.
+- Unit tests and lint/build commands available through PNPM.
+
+## Slide 13 — TFM Review Resources
+
+**Bullets:**
+
+- Documentation: `README.md`.
+- Deployment guide: `read first/GUIA-DESPLIEGUE.md`.
+- Test manual: `read first/MANUAL-CASOS-DE-PRUEBA.md`.
+- Slides: `docs/presentation/TFM-SLIDES.md`.
+- Video script: `docs/video/TFM-VIDEO-SCRIPT.md`.
+
+## Slide 14 — Conclusions and Future Work
+
+**Bullets:**
+
+- Lucis Gestión covers the complete operational workflow for a small bakery.
+- Demo mode makes evaluation frictionless.
+- Firebase provides a practical production deployment path.
+- Future improvements: advanced role-based UI hiding, richer analytics, online ordering, payment integration, and automated E2E coverage.
+
+## Prompt to Generate a Visual Presentation Later
+
+Use this prompt in Google Slides AI, Canva, Gamma, Tome, PowerPoint Copilot, or another slide generator:
+
+```text
+Create a professional 14-slide English presentation for a Final Master's Project called "Lucis Gestión". It is an Angular 22 and Firebase web/PWA application for managing an artisanal bakery. Use a modern, clean, warm bakery-inspired visual style with soft beige, cream, chocolate, and accent green colors. Include these slides: title; problem and motivation; proposed solution; target users and scope; technology stack; architecture; main workflow; demo mode with URL https://lucis-gestion-6cea2.web.app/demo; recipe costing; sales and stock; dashboard and financial reports; deployment and quality; TFM review resources; conclusions and future work. Mention that demo mode requires no credentials and uses temporary in-memory sample data. Leave image placeholders for dashboard, recipe costing, sales flow, stock view, and financial reports. Use concise bullets and speaker notes for a 7-minute presentation.
+```

--- a/docs/video/TFM-VIDEO-SCRIPT.md
+++ b/docs/video/TFM-VIDEO-SCRIPT.md
@@ -1,0 +1,102 @@
+# TFM Video Script — Lucis Gestión
+
+This script is designed for a screen-recorded explanation of the project. The recommended duration is 6 to 8 minutes.
+
+## Recording Setup
+
+- Open the deployed demo before starting: <https://lucis-gestion-6cea2.web.app/demo>
+- Record the full browser window.
+- Optional: include webcam overlay.
+- Keep the README open in another tab to show documentation and delivery resources.
+- At the end, paste the final public video URL in the README or in the delivery platform.
+
+## 0:00 — Introduction
+
+Hello, my name is [your name], and this is the presentation of my Final Master's Project: Lucis Gestión.
+
+Lucis Gestión is a web application designed for a small handmade bakery or pastry business. Its goal is to centralize recipe costing, ingredient stock, sales, customer management, fixed costs, and financial reporting in one responsive application.
+
+For this review I will use the public demo mode, which does not require username or password.
+
+## 0:45 — Access and Demo Mode
+
+On screen, I open the deployed application at:
+
+<https://lucis-gestion-6cea2.web.app/demo>
+
+This route automatically starts the application as an owner user and loads sample data. The reviewer can safely test the system because demo data is stored in memory and resets after refreshing the browser.
+
+## 1:20 — Dashboard Overview
+
+This is the dashboard. It summarizes the current business situation with key performance indicators such as revenue, costs, net profit, and best-selling products.
+
+The dashboard also includes low-stock alerts, so the owner can quickly detect which ingredients need to be purchased. The period filters allow the user to review information for different time ranges, such as today, week, or month.
+
+## 2:00 — Ingredients and Stock
+
+Now I open the Ingredients section. Here the user can create and manage the ingredients used by the bakery.
+
+Each ingredient stores its measurement unit, price, current stock, minimum stock, and category. This information is essential because recipe costs are calculated from ingredient prices.
+
+When prices change, the system keeps a price history and can update recipe cost calculations. This helps the business keep selling prices aligned with real production costs.
+
+Next, I open the Stock section. The application displays stock status with visual indicators, making it easy to identify critical, low, and healthy inventory levels.
+
+## 3:00 — Recipes and Cost Calculation
+
+Now I open Recipes. A recipe is built from ingredients and quantities. The application calculates the total production cost and then applies a margin to suggest a sale price.
+
+This feature is one of the core parts of the project because it solves a common business problem: knowing whether a product is profitable after ingredient price changes.
+
+The recipe module also supports duplication and catalog sharing or printing, which helps the owner quickly create product variations and communicate products to customers.
+
+## 4:00 — Sales Flow
+
+Now I open Sales. Here the user can register an order, select one or more recipes, assign a customer, choose a payment method, and confirm the sale.
+
+When a sale is registered, the system deducts the required ingredients from stock according to each recipe. Sales can be pending, delivered, or cancelled, which reflects the operational status of customer orders.
+
+The application also includes WhatsApp actions to help contact customers with order information.
+
+## 5:00 — Customers and Communication
+
+In the Customers section, the user can create, edit, search, and delete customer records. Each customer can include a phone number and address.
+
+The WhatsApp shortcut is useful for a small business because many orders are coordinated directly through messaging. The system reduces manual work by preparing communication actions from stored customer data.
+
+## 5:40 — Financial Reports and Fixed Costs
+
+Next, I open the Financial Reports area. This section provides a more analytical view of the business, including financial indicators, top products, top customers, low-stock information, and recommendations.
+
+The application also supports exports to PDF and Excel. This is important because it allows the owner to keep external records or share reports.
+
+Fixed costs can also be registered, which gives a more complete view of profitability beyond variable ingredient costs.
+
+## 6:40 — Technical Overview
+
+Technically, Lucis Gestión is built with Angular 22 using standalone components, Angular signals, and NgRx Signals for reactive state management.
+
+Firebase is used for authentication, Firestore persistence, and hosting. The project also includes a mock mode, where Firebase services are replaced by in-memory implementations for demonstration and testing.
+
+The repository includes documentation, a deployment guide, a functional test case manual, slide content, and this video script.
+
+## 7:25 — Closing
+
+To conclude, Lucis Gestión covers the full operational cycle of a small bakery: ingredients, recipes, prices, stock, sales, customers, dashboard metrics, financial reports, and deployment.
+
+The public demo route allows the evaluator to test the project immediately without credentials:
+
+<https://lucis-gestion-6cea2.web.app/demo>
+
+Thank you for watching the presentation.
+
+## Short Checklist While Recording
+
+1. Show the demo URL.
+2. Show dashboard KPIs.
+3. Show ingredients and stock.
+4. Show recipe costing.
+5. Register or inspect a sale.
+6. Show customers and WhatsApp action.
+7. Show reports/export area.
+8. Show README delivery resources.

--- a/read first/GUIA-DESPLIEGUE.md
+++ b/read first/GUIA-DESPLIEGUE.md
@@ -1,387 +1,203 @@
-# 🚀 Guía de Despliegue — Lucis Gestión
+# Deployment Guide — Lucis Gestión
 
-## Índice
+This guide explains how to configure and deploy Lucis Gestión to Firebase Hosting for a production-like TFM review.
 
-1. [Pre-requisitos](#1-pre-requisitos)
-2. [Crear proyecto en Firebase](#2-crear-proyecto-en-firebase)
-3. [Configurar autenticación](#3-configurar-autenticación)
-4. [Configurar Firestore](#4-configurar-firestore)
-5. [Conectar el código con Firebase](#5-conectar-el-código-con-firebase)
-6. [Build y deploy](#6-build-y-deploy)
-7. [Verificaciones post-deploy](#7-verificaciones-post-deploy)
-8. [Cosas que faltan / Mejoras pendientes](#8-cosas-que-faltan--mejoras-pendientes)
-9. [Troubleshooting](#9-troubleshooting)
+## Current Public Deployment
 
----
+- **Application:** <https://lucis-gestion-6cea2.web.app/>
+- **Demo mode:** <https://lucis-gestion-6cea2.web.app/demo>
+- **Recommended evaluator access:** demo mode, because it does not require login and includes sample data.
 
-## 1. Pre-requisitos
+## 1. Prerequisites
 
-### Software necesario
-
-| Herramienta | Versión mínima | Comando para verificar |
+| Tool | Version / requirement | Check command |
 |---|---|---|
-| Node.js | 20+ | `node --version` |
-| pnpm | 10+ | `pnpm --version` |
-| Angular CLI | 21+ | `ng version` |
-| Firebase CLI | 13+ | `firebase --version` |
+| Node.js | `>=22.22.3` | `node --version` |
+| pnpm | `11.1.1` or compatible | `pnpm --version` |
+| Angular CLI | Compatible with Angular 22 | `pnpm ng version` |
+| Firebase CLI | Required for deploy | `firebase --version` |
 
-### Instalar Firebase CLI (si no lo tenés)
+Install dependencies:
+
+```bash
+pnpm install
+```
+
+Install Firebase CLI if it is not available:
 
 ```bash
 pnpm install -g firebase-tools
 ```
 
-### Iniciar sesión en Firebase desde la terminal
+Authenticate with Firebase:
 
 ```bash
 firebase login
 ```
 
-Se abrirá el navegador para autenticarte con tu cuenta de Google.
+## 2. Firebase Project Setup
 
----
+1. Open <https://console.firebase.google.com/>.
+2. Create or select a Firebase project.
+3. Register a web application.
+4. Enable Firebase Hosting during app registration.
+5. Copy the Firebase web configuration object.
 
-## 2. Crear proyecto en Firebase
+Example configuration shape:
 
-1. Ir a [Firebase Console](https://console.firebase.google.com/)
-2. Click en **"Agregar proyecto"** (o "Add project")
-3. Nombre: `lucis-gestion` (o el que quieras)
-4. **Desactivar Google Analytics** (no lo necesitamos, simplifica el setup)
-5. Click en **"Crear proyecto"**
-6. Esperar a que se cree → Click en "Continuar"
-
-### Registrar la Web App
-
-1. En la pantalla principal del proyecto, click en el ícono **Web** (`</>`)
-2. Nombre: `Lucis Gestión`
-3. **✅ Marcar** "Also set up Firebase Hosting"
-4. Click en "Register app"
-5. **⚠️ COPIAR la configuración** que aparece (la vas a necesitar en el paso 5):
-
-```javascript
+```ts
 const firebaseConfig = {
-  apiKey: "AIza...",
-  authDomain: "lucis-gestion-XXXXX.firebaseapp.com",
-  projectId: "lucis-gestion-XXXXX",
-  storageBucket: "lucis-gestion-XXXXX.appspot.com",
-  messagingSenderId: "123456789",
-  appId: "1:123456789:web:abcdef"
+  apiKey: '...',
+  authDomain: 'lucis-gestion-6cea2.firebaseapp.com',
+  projectId: 'lucis-gestion-6cea2',
+  storageBucket: 'lucis-gestion-6cea2.appspot.com',
+  messagingSenderId: '...',
+  appId: '...',
 };
 ```
 
----
+## 3. Authentication Setup
 
-## 3. Configurar autenticación
+1. Go to **Firebase Console → Authentication**.
+2. Open **Sign-in method**.
+3. Enable **Google**.
+4. Add a support email.
+5. In **Settings → Authorized domains**, verify that the deployed domain is present:
+   - `lucis-gestion-6cea2.web.app`
+   - `localhost` for local development
 
-1. En Firebase Console → **Authentication** (menú lateral)
-2. Click en **"Comenzar"** / "Get Started"
-3. En la pestaña **"Sign-in method"**:
-   - Click en **Google**
-   - Activar el toggle
-   - Agregar un correo de soporte (el tuyo)
-   - Click en **Guardar**
-4. En la pestaña **"Settings" → "Authorized domains"**:
-   - Verificar que `lucis-gestion-XXXXX.web.app` esté listado
-   - Si vas a probar localmente, `localhost` ya debería estar
+## 4. Firestore Setup
 
----
+1. Go to **Firebase Console → Firestore Database**.
+2. Create a database.
+3. Select the closest region to the expected users.
+4. Start with temporary test rules only if the project is not public yet.
+5. Deploy the repository rules before real usage.
 
-## 4. Configurar Firestore
+The application creates collections automatically when data is written. Main collections include:
 
-1. En Firebase Console → **Firestore Database** (menú lateral)
-2. Click en **"Crear base de datos"** / "Create database"
-3. **Ubicación**: elegir la más cercana. Para Argentina: `southamerica-east1` (São Paulo)
-   > ⚠️ **LA UBICACIÓN NO SE PUEDE CAMBIAR DESPUÉS**
-4. Reglas de seguridad: elegir **"Empezar en modo de prueba"** (las vamos a reemplazar)
-5. Click en "Crear"
-
-### Subir las reglas de seguridad
-
-Las reglas ya están definidas en el archivo `firestore.rules` del proyecto. Se suben automáticamente con `firebase deploy`. Pero si querés verificar antes:
-
-1. En Firebase Console → Firestore → pestaña **"Reglas"**
-2. Copiar el contenido de `firestore.rules` del proyecto
-3. Click en "Publicar"
-
-### Colecciones que se crean automáticamente
-
-No necesitás crear colecciones manualmente. Se crean solas cuando la app escribe el primer documento:
-
-| Colección | Se crea cuando... |
+| Collection | Purpose |
 |---|---|
-| `users` | Primer login |
-| `ingredientes` | Se crea el primer ingrediente |
-| `recetas` | Se crea la primera receta |
-| `ventas` | Se registra la primera venta |
-| `clientes` | Se crea el primer cliente |
-| `movimientosStock` | Se registra la primera venta (automático) |
-| `gastosInsumos` | Se registra la primera compra de insumos |
-| `historialPrecios` | Se cambia el precio de un ingrediente |
+| `users` | Authenticated user profile and role |
+| `ingredientes` | Ingredients, stock, prices, and categories |
+| `recetas` | Recipes and cost information |
+| `ventas` | Orders and sales history |
+| `clientes` | Customer records |
+| `movimientosStock` | Inventory movements |
+| `gastosInsumos` | Ingredient purchase expenses |
+| `historialPrecios` | Ingredient price changes |
+| `costosFijos` | Monthly fixed costs |
 
----
+## 5. Environment Configuration
 
-## 5. Conectar el código con Firebase
+Create or update `src/environments/environment.ts` with the Firebase configuration:
 
-### 5.1 Archivo de environment
-
-Editar `src/environments/environment.ts` y reemplazar los placeholders:
-
-```typescript
+```ts
 export const environment = {
   production: false,
   firebase: {
-    apiKey: 'TU_API_KEY_REAL',
-    authDomain: 'lucis-gestion-XXXXX.firebaseapp.com',
-    projectId: 'lucis-gestion-XXXXX',
-    storageBucket: 'lucis-gestion-XXXXX.appspot.com',
-    messagingSenderId: 'TU_SENDER_ID',
-    appId: 'TU_APP_ID',
+    apiKey: 'YOUR_API_KEY',
+    authDomain: 'lucis-gestion-6cea2.firebaseapp.com',
+    projectId: 'lucis-gestion-6cea2',
+    storageBucket: 'lucis-gestion-6cea2.appspot.com',
+    messagingSenderId: 'YOUR_SENDER_ID',
+    appId: 'YOUR_APP_ID',
   },
 };
 ```
 
-### 5.2 Crear environment de producción
+For production builds, keep the production environment aligned with the same Firebase project and set `production: true` if a dedicated production file is used.
 
-Crear archivo `src/environments/environment.prod.ts`:
+## 6. Firebase Project Alias
 
-```typescript
-export const environment = {
-  production: true,
-  firebase: {
-    apiKey: 'TU_API_KEY_REAL',
-    authDomain: 'lucis-gestion-XXXXX.firebaseapp.com',
-    projectId: 'lucis-gestion-XXXXX',
-    storageBucket: 'lucis-gestion-XXXXX.appspot.com',
-    messagingSenderId: 'TU_SENDER_ID',
-    appId: 'TU_APP_ID',
-  },
-};
-```
-
-> ℹ️ Pueden ser iguales. La diferencia es el flag `production: true`.
-
-### 5.3 Archivo `.firebaserc`
-
-Editar `.firebaserc` y reemplazar el project ID:
+Ensure `.firebaserc` points to the intended Firebase project:
 
 ```json
 {
   "projects": {
-    "default": "lucis-gestion-XXXXX"
+    "default": "lucis-gestion-6cea2"
   }
 }
 ```
 
-> Usá el mismo `projectId` que copiaste de la configuración de Firebase.
+## 7. Local Verification Before Deploy
 
----
-
-## 6. Build y deploy
-
-### Probar en modo desarrollo (local)
+Run the Firebase-backed application:
 
 ```bash
-cd lucis-gestion
 pnpm start
 ```
 
-Abrir `http://localhost:4200` — verificar que el login con Google funcione.
-
-### Probar en modo mock (sin Firebase)
-
-Si querés verificar que la UI funciona antes de configurar Firebase:
+Run the mock/demo version without Firebase:
 
 ```bash
 pnpm start:mock
 ```
 
-Esto levanta la app con datos de prueba en memoria, sin necesidad de Firebase, sin login real. Ideal para hacer una primera revisión o demo rápida. Ver detalle en el [README](../README.md).
-
-### Build de producción
+Run checks before deployment:
 
 ```bash
-ng build
+pnpm test
+pnpm lint
+pnpm build
 ```
 
-Esperado: 0 errores, 0 warnings, ~997 kB initial bundle.
+## 8. Production Build and Deploy
 
-La salida va a `dist/lucis-gestion/browser/`.
+Build the application:
 
-### Deploy a Firebase Hosting
+```bash
+pnpm build
+```
+
+Deploy hosting, Firestore rules, and indexes:
 
 ```bash
 firebase deploy
 ```
 
-Esto sube:
-- ✅ La app (hosting)
-- ✅ Las reglas de Firestore (`firestore.rules`)
-- ✅ Los índices de Firestore (`firestore.indexes.json`)
-
-Al finalizar te da la URL:
-
-```
-✔ Deploy complete!
-
-Hosting URL: https://lucis-gestion-XXXXX.web.app
-```
-
-### (Opcional) Deploy solo hosting
+Deploy only hosting if rules and indexes did not change:
 
 ```bash
 firebase deploy --only hosting
 ```
 
-### (Opcional) Deploy solo reglas
+Deploy only Firestore rules and indexes:
 
 ```bash
-firebase deploy --only firestore:rules
+firebase deploy --only firestore
 ```
 
----
+Expected final output includes a Firebase Hosting URL similar to:
 
-## 7. Verificaciones post-deploy
-
-### Checklist obligatorio
-
-- [ ] **Abrir la URL** `https://lucis-gestion-XXXXX.web.app` en el celular
-- [ ] **Login con Google** funciona (no da error de dominio no autorizado)
-- [ ] **Primer usuario** se registra como `owner` en Firestore → verificar en Console: Firestore → colección `users`
-- [ ] **Crear un ingrediente** de prueba → verificar que aparece en Firestore
-- [ ] **Crear una receta** → verificar que calcula el costo
-- [ ] **Registrar una venta** → verificar que el stock se descuenta
-- [ ] **Instalar como PWA**: en Chrome mobile, debería aparecer el banner "Agregar a pantalla de inicio" o desde menú → "Instalar app"
-- [ ] **Modo offline**: apagar WiFi/datos, verificar que la app sigue mostrando datos cargados
-- [ ] **Segundo usuario**: iniciar sesión con otra cuenta → debe quedar como `ayudante`
-
-### Verificar en Firebase Console
-
-| Qué verificar | Dónde |
-|---|---|
-| Usuarios registrados | Authentication → Users |
-| Datos guardados | Firestore Database → colecciones |
-| Reglas activas | Firestore → Rules |
-| Tráfico hosting | Hosting → Dashboard |
-| Uso del free tier | Usage and billing |
-
----
-
-## 8. Cosas que faltan / Mejoras pendientes
-
-### 🔴 Crítico (hacer antes de dar acceso a usuarios)
-
-| # | Qué falta | Detalle |
-|---|---|---|
-| 1 | **Configurar Firebase real** | Reemplazar los placeholders en `environment.ts` y `.firebaserc` con valores reales del proyecto Firebase |
-| 2 | **Roles con Custom Claims** | Actualmente los roles se guardan en Firestore (`users/{uid}.role`), pero las Firestore rules usan `request.auth.token.role` (custom claims). **Hay un mismatch**: necesitás una Cloud Function o script Admin SDK que copie el rol de Firestore al token. Alternativa: cambiar las rules para leer de Firestore en vez de claims. Ver sección Troubleshooting |
-| 3 | **Environment de producción** | Crear `environment.prod.ts` y configurar `angular.json` para usarlo en build de producción |
-
-### 🟡 Importante (mejora la experiencia)
-
-| # | Qué falta | Detalle |
-|---|---|---|
-| 4 | **Ocultar UI según rol** | El ayudante ve botones de crear/editar ingredientes y recetas pero Firestore los rechaza. Conviene ocultar esos botones con `@if (auth.isOwner())` |
-| 5 | **Teléfonos WhatsApp con código país** | Si los teléfonos no incluyen código país (ej: `+54`), el link `wa.me` no funciona correctamente. Agregar validación o prefijo automático |
-| 6 | **Reponer stock en cancelación** | Si se cancela una venta, el stock NO se repone automáticamente. Decidir si implementar o dejarlo como ajuste manual |
-| 7 | **Error handling global** | No hay toasts/snackbar para errores de Firestore (offline, permisos). Agregar manejo en el store |
-| 8 | **Loading indicators** | El estado `loading` del store no se muestra en la UI. Agregar spinners en operaciones lentas |
-
-### 🟢 Nice-to-have (mejoras futuras)
-
-| # | Idea | Detalle |
-|---|---|---|
-| 9 | Fotos de recetas | Subir imagen con Firebase Storage |
-| 10 | Notificaciones push | FCM para avisar stock bajo |
-| 11 | Reportes exportables | Exportar ventas a CSV/Excel |
-| 12 | Multi-negocio | Soportar más de una pastelería con un solo login |
-| 13 | Backup automático | Firebase scheduled exports |
-| 14 | Tests unitarios | Actualmente 0 tests. Agregar al menos para el store |
-
----
-
-## 9. Troubleshooting
-
-### Error: "auth/unauthorized-domain"
-
-El dominio desde donde accedés no está autorizado en Firebase Auth.
-
-**Solución**: Firebase Console → Authentication → Settings → Authorized domains → Agregar tu dominio.
-
-### Error: "Missing or insufficient permissions" en Firestore
-
-Las Firestore rules requieren `request.auth.token.role` (Custom Claims), pero el sistema actual guarda el rol en un documento de Firestore, no en el token.
-
-**Solución rápida** — Cambiar las rules para leer de Firestore:
-
-```javascript
-function getUserRole() {
-  return get(/databases/$(database)/documents/users/$(request.auth.uid)).data.role;
-}
-
-function isOwner() {
-  return isSignedIn() && getUserRole() == 'owner';
-}
+```text
+Hosting URL: https://lucis-gestion-6cea2.web.app
 ```
 
-> ⚠️ Esto agrega 1 lectura extra de Firestore por cada operación. Es aceptable para volumen bajo (10-30 pedidos/semana) pero no escala. La solución ideal es una Cloud Function que setee Custom Claims.
+## 9. Post-deploy Checklist
 
-**Solución ideal** — Cloud Function para custom claims:
+- Open <https://lucis-gestion-6cea2.web.app/> and verify that the landing page loads.
+- Open <https://lucis-gestion-6cea2.web.app/demo> and verify that demo data appears without login.
+- Test Google login from the production entry point.
+- Verify direct navigation to nested routes such as `/demo/dashboard` and `/app/dashboard`.
+- Confirm Firestore rules are published from `firestore.rules`.
+- Confirm Firestore indexes are published from `firestore.indexes.json`.
+- Confirm the PWA manifest loads correctly.
 
-```javascript
-// functions/index.js
-const functions = require('firebase-functions');
-const admin = require('firebase-admin');
-admin.initializeApp();
+## 10. Troubleshooting
 
-exports.onUserCreated = functions.firestore
-  .document('users/{userId}')
-  .onCreate(async (snap, context) => {
-    const { role } = snap.data();
-    await admin.auth().setCustomUserClaims(context.params.userId, { role });
-  });
-```
-
-### El service worker cachea una versión vieja
-
-**Solución**: En Chrome DevTools → Application → Service Workers → "Update on reload" o "Unregister".
-
-### La PWA no se instala
-
-Requisitos:
-- Debe servirse por HTTPS (Firebase Hosting lo incluye)
-- Debe tener `manifest.webmanifest` válido (ya incluido)
-- Debe tener Service Worker registrado (ya incluido)
-- El usuario debe interactuar con la app al menos 30 segundos
-
-### Build supera el warning de 1 MB
-
-Actualmente el bundle es ~997 kB (muy justo). Si se agregan más features:
-- Usar `ng build` con `--stats-json` y analizar con `webpack-bundle-analyzer`
-- Verificar que todo sea lazy-loaded
-- Considerar quitar módulos de Material no usados
-
----
-
-## Resumen de archivos a modificar antes del deploy
-
-| Archivo | Qué cambiar |
-|---|---|
-| `src/environments/environment.ts` | Reemplazar TODOS los placeholders de Firebase config |
-| `src/environments/environment.prod.ts` | Crear con los mismos valores + `production: true` |
-| `.firebaserc` | Cambiar `YOUR_PROJECT_ID` por el ID real del proyecto |
-| `firestore.rules` | (Opcional) Cambiar de custom claims a lectura de Firestore — ver Troubleshooting |
-
----
-
-## Costos esperados (Plan Spark — Gratis)
-
-| Recurso | Límite gratuito | Uso estimado (10-30 pedidos/semana) |
+| Problem | Likely cause | Suggested fix |
 |---|---|---|
-| Firestore reads | 50,000/día | ~500-2,000/día ✅ |
-| Firestore writes | 20,000/día | ~50-200/día ✅ |
-| Firestore storage | 1 GB | < 10 MB ✅ |
-| Hosting storage | 10 GB | ~5 MB ✅ |
-| Hosting bandwidth | 10 GB/mes | ~100 MB/mes ✅ |
-| Auth users | Sin límite | 2-5 usuarios ✅ |
+| Blank page after deploy | Build output path mismatch | Check `firebase.json` hosting `public` directory |
+| Google login fails | Unauthorized domain | Add the domain in Firebase Authentication settings |
+| Firestore permission denied | Rules or user role mismatch | Review `firestore.rules` and user role in `users/{uid}` |
+| Local Firebase mode fails | Missing environment config | Update `src/environments/environment.ts` |
+| Demo mode data disappears | Expected in-memory behavior | Refreshing resets mock state by design |
 
-> Con el volumen esperado, **no hay riesgo de superar el plan gratuito**.
+## 11. Notes for TFM Evaluation
+
+The preferred evaluation path is the public demo URL because it avoids account creation and gives the reviewer immediate access to a representative bakery dataset:
+
+```text
+https://lucis-gestion-6cea2.web.app/demo
+```

--- a/read first/MANUAL-CASOS-DE-PRUEBA.md
+++ b/read first/MANUAL-CASOS-DE-PRUEBA.md
@@ -1,359 +1,350 @@
-# 🧪 Manual de Casos de Prueba — Lucis Gestión
+# Functional Test Case Manual — Lucis Gestión
 
-## Modo Mock (ejecución rápida sin Firebase)
+This manual defines the functional checks for the TFM review of Lucis Gestión. The recommended review mode is the public demo route because it avoids account creation and includes representative sample data.
 
-Para ejecutar los casos de prueba sin necesidad de Firebase configurado:
+## Recommended Test Access
 
-```bash
-pnpm start:mock
-```
+- **Public deployment:** <https://lucis-gestion-6cea2.web.app/>
+- **Demo route:** <https://lucis-gestion-6cea2.web.app/demo>
+- **Local demo command:** `pnpm start:mock`
+- **Demo credentials:** none required
+- **Demo role:** owner
+- **Persistence:** in-memory; changes reset after refresh/restart
 
-La app se levanta con datos de ejemplo precargados (ingredientes, recetas, clientes y ventas). El usuario queda auto-logueado como owner. Los datos se pierden al refrescar.
+## Conventions
 
-> **Nota**: Los casos CP-01 a CP-04 (autenticación) y CP-27/CP-28 (PWA/offline) requieren Firebase real. El resto se pueden validar en modo mock.
+- **Precondition:** Required state before executing the case.
+- **Steps:** Ordered actions.
+- **Expected result:** Observable result if the feature works correctly.
+- **Status:** Pending until executed by the evaluator.
 
-## Convenciones
+## Authentication and Access
 
-- **Pre-condición**: Estado necesario antes de ejecutar el caso.
-- **Pasos**: Acciones a seguir en orden.
-- **Resultado esperado**: Lo que debe ocurrir si todo funciona correctamente.
-- ✅ = Pasó | ❌ = Falló | ⏳ = Pendiente
+### TC-01: Demo access without login
 
----
-
-## 1. Autenticación (Fase 4)
-
-### CP-01: Login con Google — Primer usuario (Owner)
-
-| Campo | Detalle |
+| Field | Detail |
 |---|---|
-| **Pre-condición** | No existe ningún documento en la colección `users` de Firestore |
-| **Pasos** | 1. Abrir la app → debería redirigir a `/login` <br> 2. Tocar "Continuar con Google" <br> 3. Seleccionar cuenta de Google |
-| **Resultado esperado** | ✅ Se crea documento en `users/{uid}` con `role: 'owner'` <br> ✅ Redirige a `/dashboard` <br> ✅ En el menú de usuario aparece badge "Dueña" |
-| **Estado** | ⏳ |
+| Precondition | Application deployed or running with `pnpm start:mock` |
+| Steps | 1. Open `/demo` or `/demo/dashboard` |
+| Expected result | The app opens the authenticated layout with sample data and no login prompt. |
+| Status | Pending |
 
-### CP-02: Login con Google — Segundo usuario (Ayudante)
+### TC-02: Google login for Firebase mode
 
-| Campo | Detalle |
+| Field | Detail |
 |---|---|
-| **Pre-condición** | Ya existe al menos un usuario en `users` |
-| **Pasos** | 1. Abrir la app en otro navegador/incógnito <br> 2. Tocar "Continuar con Google" con otra cuenta |
-| **Resultado esperado** | ✅ Se crea documento con `role: 'ayudante'` <br> ✅ Badge muestra "Ayudante" |
-| **Estado** | ⏳ |
+| Precondition | Firebase Authentication configured with Google provider |
+| Steps | 1. Open `/login` 2. Click Google login 3. Select account |
+| Expected result | The user is authenticated and redirected to `/app/dashboard`. First user receives owner permissions. |
+| Status | Pending |
 
-### CP-03: Logout
+### TC-03: Logout
 
-| Campo | Detalle |
+| Field | Detail |
 |---|---|
-| **Pre-condición** | Usuario logueado |
-| **Pasos** | 1. Tocar avatar en toolbar <br> 2. Tocar "Cerrar sesión" |
-| **Resultado esperado** | ✅ Redirige a `/login` <br> ✅ No se puede acceder a `/dashboard` directamente |
-| **Estado** | ⏳ |
+| Precondition | User authenticated in Firebase mode |
+| Steps | 1. Open the user menu 2. Click logout |
+| Expected result | Session closes and protected `/app/*` routes require authentication again. |
+| Status | Pending |
 
-### CP-04: Acceso sin autenticación
+### TC-04: Protected route access
 
-| Campo | Detalle |
+| Field | Detail |
 |---|---|
-| **Pre-condición** | No hay sesión activa |
-| **Pasos** | 1. Navegar directamente a `/dashboard`, `/recetas`, `/ventas` |
-| **Resultado esperado** | ✅ Redirige a `/login` en todos los casos |
-| **Estado** | ⏳ |
+| Precondition | No Firebase session is active |
+| Steps | 1. Navigate directly to `/app/dashboard`, `/app/recetas`, and `/app/ventas` |
+| Expected result | The app redirects unauthenticated users to login. |
+| Status | Pending |
 
----
+## Ingredients and Price History
 
-## 2. Ingredientes (Fase 1)
+### TC-05: Create ingredient
 
-### CP-05: Crear ingrediente
-
-| Campo | Detalle |
+| Field | Detail |
 |---|---|
-| **Pre-condición** | Usuario logueado como owner |
-| **Pasos** | 1. Ir a Ingredientes (desde menú o `/ingredientes`) <br> 2. Tocar botón FAB (+) <br> 3. Completar: Nombre="Harina 000", Unidad="kg", Categoría="Secos", Precio=$500, Stock actual=10, Stock mínimo=2 <br> 4. Tocar "Crear" |
-| **Resultado esperado** | ✅ Aparece el ingrediente en la lista <br> ✅ Muestra precio `$500,00 / kg` <br> ✅ Stock en verde (10 > 2) |
-| **Estado** | ⏳ |
+| Precondition | Demo or owner user active |
+| Steps | 1. Open Ingredients 2. Add an ingredient 3. Fill name, unit, category, price, current stock, and minimum stock 4. Save |
+| Expected result | The ingredient appears in the list with formatted price and stock status. |
+| Status | Pending |
 
-### CP-06: Editar ingrediente — cambio de precio con cascada
+### TC-06: Edit ingredient price
 
-| Campo | Detalle |
+| Field | Detail |
 |---|---|
-| **Pre-condición** | Ingrediente "Harina 000" existe y está usado en al menos 1 receta |
-| **Pasos** | 1. Tocar card del ingrediente <br> 2. Cambiar precio de $500 a $700 <br> 3. Tocar "Guardar" |
-| **Resultado esperado** | ✅ Snackbar dice "Ingrediente actualizado. Recetas recalculadas." <br> ✅ Todas las recetas que usan Harina muestran nuevo costo <br> ✅ Se crea registro en `historialPrecios` |
-| **Estado** | ⏳ |
+| Precondition | Ingredient used by at least one recipe exists |
+| Steps | 1. Edit ingredient 2. Change price 3. Save |
+| Expected result | The ingredient price updates, related recipe costs are recalculated, and price history records the change. |
+| Status | Pending |
 
-### CP-07: Buscar ingrediente
+### TC-07: Search ingredient
 
-| Campo | Detalle |
+| Field | Detail |
 |---|---|
-| **Pre-condición** | Existen al menos 3 ingredientes |
-| **Pasos** | 1. Escribir "har" en la barra de búsqueda |
-| **Resultado esperado** | ✅ Solo se muestran ingredientes cuyo nombre contiene "har" <br> ✅ Al borrar el texto, vuelven todos |
-| **Estado** | ⏳ |
+| Precondition | Multiple ingredients exist |
+| Steps | 1. Type a partial ingredient name in the search field |
+| Expected result | The list filters case-insensitively and restores all items when the search is cleared. |
+| Status | Pending |
 
-### CP-08: Eliminar ingrediente (soft delete)
+### TC-08: Delete ingredient
 
-| Campo | Detalle |
+| Field | Detail |
 |---|---|
-| **Pre-condición** | Ingrediente existente |
-| **Pasos** | 1. Tocar card del ingrediente <br> 2. Tocar "Eliminar" en el dialog |
-| **Resultado esperado** | ✅ Desaparece de la lista <br> ✅ En Firestore, `activo: false` (no se borra físicamente) |
-| **Estado** | ⏳ |
+| Precondition | Ingredient exists |
+| Steps | 1. Open ingredient details 2. Delete 3. Confirm |
+| Expected result | Ingredient disappears from active lists and remains soft-deleted in persisted mode. |
+| Status | Pending |
 
-### CP-09: Ver historial de precios
+### TC-09: Review price history
 
-| Campo | Detalle |
+| Field | Detail |
 |---|---|
-| **Pre-condición** | Ingrediente con al menos un cambio de precio |
-| **Pasos** | 1. Tocar ícono de reloj (history) en la card del ingrediente |
-| **Resultado esperado** | ✅ Se abre dialog con lista de cambios <br> ✅ Muestra precio anterior → nuevo, con fecha <br> ✅ Flecha roja si subió, verde si bajó |
-| **Estado** | ⏳ |
+| Precondition | Ingredient has at least one price change |
+| Steps | 1. Open the ingredient price history action |
+| Expected result | A history view displays previous price, new price, date, and change direction. |
+| Status | Pending |
 
----
+## Recipes and Catalog
 
-## 3. Recetas (Fase 1)
+### TC-10: Create recipe with cost calculation
 
-### CP-10: Crear receta con cálculo de costo
-
-| Campo | Detalle |
+| Field | Detail |
 |---|---|
-| **Pre-condición** | Existen ingredientes: Harina ($500/kg), Azúcar ($400/kg), Huevos ($200/doc) |
-| **Pasos** | 1. Ir a Recetas → FAB (+) <br> 2. Nombre="Torta Básica", Categoría="Tortas", Rendimiento=1 <br> 3. Agregar: Harina 0.5kg, Azúcar 0.3kg, Huevos 1doc <br> 4. Margen=60% <br> 5. Guardar |
-| **Resultado esperado** | ✅ Costo calculado = $500×0.5 + $400×0.3 + $200×1 = $570 <br> ✅ Precio sugerido = $570 × 1.6 = $912 <br> ✅ Aparece en la lista con los 3 valores |
-| **Estado** | ⏳ |
+| Precondition | Ingredients with prices exist |
+| Steps | 1. Open Recipes 2. Add recipe 3. Add ingredients and quantities 4. Set margin 5. Save |
+| Expected result | Total cost and suggested price are calculated from ingredient prices and margin. |
+| Status | Pending |
 
-### CP-11: Duplicar receta
+### TC-11: Duplicate recipe
 
-| Campo | Detalle |
+| Field | Detail |
 |---|---|
-| **Pre-condición** | Existe receta "Torta Básica" |
-| **Pasos** | 1. Tocar ícono de 3 puntos (⋮) en la card <br> 2. Tocar "Duplicar" |
-| **Resultado esperado** | ✅ Aparece nueva receta "Torta Básica (copia)" <br> ✅ Mismos ingredientes, costo y precio que la original |
-| **Estado** | ⏳ |
+| Precondition | At least one recipe exists |
+| Steps | 1. Open recipe actions 2. Duplicate recipe |
+| Expected result | A copy appears with the same ingredients, cost, and suggested price. |
+| Status | Pending |
 
-### CP-12: Compartir catálogo
+### TC-12: Share catalog
 
-| Campo | Detalle |
+| Field | Detail |
 |---|---|
-| **Pre-condición** | Existen al menos 2 recetas |
-| **Pasos** | 1. Tocar botón "Catálogo" en la esquina superior <br> 2. En el dialog, tocar "Compartir" (mobile) o verificar que se copia al portapapeles (desktop) |
-| **Resultado esperado** | ✅ En mobile: se abre el panel nativo de compartir con texto del catálogo <br> ✅ En desktop: alerta "Catálogo copiado al portapapeles" <br> ✅ El texto incluye nombre y precio de cada receta |
-| **Estado** | ⏳ |
+| Precondition | At least two recipes exist |
+| Steps | 1. Open catalog 2. Use the share/copy action |
+| Expected result | Mobile opens native share when available; desktop copies catalog text to clipboard. |
+| Status | Pending |
 
-### CP-13: Imprimir catálogo
+### TC-13: Print catalog
 
-| Campo | Detalle |
+| Field | Detail |
 |---|---|
-| **Pre-condición** | Existen recetas |
-| **Pasos** | 1. Catálogo → tocar ícono de impresora |
-| **Resultado esperado** | ✅ Se abre ventana con vista para imprimir limpia <br> ✅ Muestra logo, nombre y lista de productos con precios |
-| **Estado** | ⏳ |
+| Precondition | Recipes exist |
+| Steps | 1. Open catalog 2. Click print |
+| Expected result | A clean print view opens with product names and prices. |
+| Status | Pending |
 
----
+## Sales and Inventory
 
-## 4. Ventas + Stock (Fase 2)
+### TC-14: Register sale and deduct stock
 
-### CP-14: Registrar venta con descuento de stock
-
-| Campo | Detalle |
+| Field | Detail |
 |---|---|
-| **Pre-condición** | Receta "Torta Básica" existe (usa 0.5kg harina, 0.3kg azúcar, 1doc huevos). Ingredientes tienen stock suficiente. |
-| **Pasos** | 1. Ir a Ventas → FAB (+) <br> 2. Agregar 2x Torta Básica <br> 3. Seleccionar cliente (opcional) <br> 4. Medio de pago: Efectivo <br> 5. Confirmar |
-| **Resultado esperado** | ✅ Venta aparece en pestaña "Pendientes" <br> ✅ Stock de Harina baja 1kg (0.5×2) <br> ✅ Stock de Azúcar baja 0.6kg (0.3×2) <br> ✅ Stock de Huevos baja 2doc (1×2) <br> ✅ Se crean documentos en `movimientosStock` |
-| **Estado** | ⏳ |
+| Precondition | Recipe and ingredient stock are available |
+| Steps | 1. Open Sales 2. Create sale 3. Add recipe quantities 4. Select payment method 5. Confirm |
+| Expected result | Sale appears as pending and required ingredient stock is deducted according to recipe quantities. |
+| Status | Pending |
 
-### CP-15: Marcar venta como entregada
+### TC-15: Mark sale as delivered
 
-| Campo | Detalle |
+| Field | Detail |
 |---|---|
-| **Pre-condición** | Venta en estado "pendiente" |
-| **Pasos** | 1. En pestaña Pendientes, tocar "Entregar ✓" |
-| **Resultado esperado** | ✅ Venta pasa a estado "entregado" <br> ✅ Chip cambia a color verde <br> ✅ Desaparece de pestaña Pendientes |
-| **Estado** | ⏳ |
+| Precondition | Pending sale exists |
+| Steps | 1. Click deliver/complete action |
+| Expected result | Sale status changes to delivered and it leaves the pending list. |
+| Status | Pending |
 
-### CP-16: Cancelar venta
+### TC-16: Cancel sale
 
-| Campo | Detalle |
+| Field | Detail |
 |---|---|
-| **Pre-condición** | Venta pendiente |
-| **Pasos** | 1. Tocar "Cancelar" en venta pendiente |
-| **Resultado esperado** | ✅ Estado cambia a "cancelado" <br> ✅ Chip en rojo <br> ⚠️ **Nota**: El stock NO se repone automáticamente (por diseño) |
-| **Estado** | ⏳ |
+| Precondition | Pending sale exists |
+| Steps | 1. Click cancel 2. Confirm |
+| Expected result | Sale status changes to cancelled. Stock is not automatically restored unless explicitly implemented by business rules. |
+| Status | Pending |
 
-### CP-17: Buscar en historial de ventas
+### TC-17: Search sales history
 
-| Campo | Detalle |
+| Field | Detail |
 |---|---|
-| **Pre-condición** | Existen varias ventas |
-| **Pasos** | 1. Ir a pestaña "Historial" <br> 2. Escribir nombre del cliente en búsqueda <br> 3. Seleccionar fecha "Desde" en datepicker |
-| **Resultado esperado** | ✅ Se filtran ventas por cliente <br> ✅ Se filtran ventas desde la fecha seleccionada <br> ✅ Ambos filtros funcionan combinados |
-| **Estado** | ⏳ |
+| Precondition | Several sales exist |
+| Steps | 1. Open sales history 2. Search by customer or filter by date |
+| Expected result | Sales list reflects the search and date filters. |
+| Status | Pending |
 
-### CP-18: Enviar pedido por WhatsApp desde ventas
+### TC-18: Send sale message by WhatsApp
 
-| Campo | Detalle |
+| Field | Detail |
 |---|---|
-| **Pre-condición** | Venta pendiente con cliente que tiene teléfono cargado |
-| **Pasos** | 1. Tocar ícono de chat (WhatsApp) en la venta pendiente |
-| **Resultado esperado** | ✅ Se abre `wa.me` con número del cliente <br> ✅ Mensaje incluye nombre, detalle de productos, cantidades y total |
-| **Estado** | ⏳ |
+| Precondition | Sale has a customer with phone number |
+| Steps | 1. Click the WhatsApp action on the sale |
+| Expected result | A `wa.me` URL opens with customer phone and generated order details. |
+| Status | Pending |
 
-### CP-19: Stock semáforo
+### TC-19: Stock traffic-light view
 
-| Campo | Detalle |
+| Field | Detail |
 |---|---|
-| **Pre-condición** | Un ingrediente con stock=0 (rojo), uno con stock≤mínimo (amarillo), uno OK (verde) |
-| **Pasos** | 1. Ir a la pestaña Stock |
-| **Resultado esperado** | ✅ Ingredientes ordenados: rojo primero, luego amarillo, luego verde <br> ✅ Barras de progreso con colores correctos <br> ✅ Los que están en 0 muestran barra vacía |
-| **Estado** | ⏳ |
+| Precondition | Ingredients have different stock levels |
+| Steps | 1. Open Stock |
+| Expected result | Out-of-stock, low-stock, and healthy-stock ingredients are visually differentiated and prioritized. |
+| Status | Pending |
 
----
+## Customers
 
-## 5. Clientes (Fase 2)
+### TC-20: Customer CRUD
 
-### CP-20: CRUD completo de clientes
-
-| Campo | Detalle |
+| Field | Detail |
 |---|---|
-| **Pre-condición** | Usuario logueado |
-| **Pasos** | 1. Ir a Clientes → FAB (+) <br> 2. Crear: Nombre="María López", Teléfono="5491112345678", Dirección="Av. Siempre Viva 742" <br> 3. Guardar → verificar en lista <br> 4. Tocar para editar → cambiar dirección → guardar <br> 5. Tocar para editar → "Eliminar" |
-| **Resultado esperado** | ✅ Cliente aparece en lista después de crear <br> ✅ Muestra teléfono y dirección <br> ✅ Edición actualiza datos <br> ✅ Eliminación lo marca como `[eliminado]` |
-| **Estado** | ⏳ |
+| Precondition | Demo or authenticated user active |
+| Steps | 1. Open Customers 2. Create customer 3. Edit address or phone 4. Delete customer |
+| Expected result | Customer list reflects create, update, and soft-delete operations. |
+| Status | Pending |
 
-### CP-21: WhatsApp desde cliente
+### TC-21: WhatsApp from customer card
 
-| Campo | Detalle |
+| Field | Detail |
 |---|---|
-| **Pre-condición** | Cliente con teléfono cargado |
-| **Pasos** | 1. Tocar ícono de chat en la card del cliente |
-| **Resultado esperado** | ✅ Se abre `wa.me/{telefono}` con saludo personalizado <br> ✅ No abre el formulario de edición (stopPropagation funciona) |
-| **Estado** | ⏳ |
+| Precondition | Customer has phone number |
+| Steps | 1. Click WhatsApp action on customer card |
+| Expected result | A `wa.me` URL opens without triggering the edit form. |
+| Status | Pending |
 
-### CP-22: Buscar cliente
+### TC-22: Search customer
 
-| Campo | Detalle |
+| Field | Detail |
 |---|---|
-| **Pre-condición** | Existen al menos 3 clientes |
-| **Pasos** | 1. Escribir nombre parcial en barra de búsqueda <br> 2. Escribir número de teléfono parcial |
-| **Resultado esperado** | ✅ Filtra por nombre <br> ✅ Filtra por teléfono <br> ✅ Búsqueda es case-insensitive |
-| **Estado** | ⏳ |
+| Precondition | Multiple customers exist |
+| Steps | 1. Search by partial name 2. Search by partial phone |
+| Expected result | Customer list filters case-insensitively by name or phone. |
+| Status | Pending |
 
----
+## Dashboard and Reports
 
-## 6. Dashboard (Fase 3)
+### TC-23: KPI period selector
 
-### CP-23: KPIs con selector de período
-
-| Campo | Detalle |
+| Field | Detail |
 |---|---|
-| **Pre-condición** | Ventas registradas en diferentes días |
-| **Pasos** | 1. Ir a Dashboard <br> 2. Selector en "Mes" → anotar valores <br> 3. Cambiar a "Hoy" <br> 4. Cambiar a "Semana" |
-| **Resultado esperado** | ✅ Ingresos, ganancia y "más vendido" cambian según período <br> ✅ "Hoy" solo muestra ventas del día actual <br> ✅ "Semana" desde el domingo <br> ✅ "Mes" desde el 1º del mes |
-| **Estado** | ⏳ |
+| Precondition | Sales exist in the selected period |
+| Steps | 1. Open Dashboard 2. Change between day, week, and month filters |
+| Expected result | Revenue, cost, profit, and best-selling product update according to the selected period. |
+| Status | Pending |
 
-### CP-24: Producto más vendido
+### TC-24: Best-selling product
 
-| Campo | Detalle |
+| Field | Detail |
 |---|---|
-| **Pre-condición** | Múltiples ventas con diferentes productos |
-| **Pasos** | 1. Verificar card "Más vendido" en dashboard |
-| **Resultado esperado** | ✅ Muestra nombre del producto con más unidades vendidas en el período <br> ✅ Muestra cantidad de unidades <br> ✅ Tiene ícono de trofeo |
-| **Estado** | ⏳ |
+| Precondition | Sales contain different products |
+| Steps | 1. Review the best-selling product card |
+| Expected result | The card displays the product with the highest quantity sold in the period. |
+| Status | Pending |
 
-### CP-25: Gráfico Ingresos vs Costos
+### TC-25: Revenue versus cost visualization
 
-| Campo | Detalle |
+| Field | Detail |
 |---|---|
-| **Pre-condición** | Ventas registradas |
-| **Pasos** | 1. Verificar sección "Ingresos vs Costos" en dashboard |
-| **Resultado esperado** | ✅ Barra verde (ingresos) es mayor que barra roja (costos) si hay ganancia <br> ✅ Valores en ARS al lado de cada barra <br> ✅ Proporciones son correctas |
-| **Estado** | ⏳ |
+| Precondition | Delivered or registered sales exist |
+| Steps | 1. Review dashboard financial comparison |
+| Expected result | Income and cost values are formatted in ARS and represented proportionally. |
+| Status | Pending |
 
-### CP-26: Alertas de stock bajo en dashboard
+### TC-26: Low-stock dashboard alert
 
-| Campo | Detalle |
+| Field | Detail |
 |---|---|
-| **Pre-condición** | Al menos un ingrediente con stock ≤ stock mínimo |
-| **Pasos** | 1. Verificar sección "Stock bajo" en dashboard |
-| **Resultado esperado** | ✅ Lista cada ingrediente bajo con cantidad actual y mínimo <br> ✅ Badge de stock en el bottom nav muestra cantidad |
-| **Estado** | ⏳ |
+| Precondition | At least one ingredient is at or below minimum stock |
+| Steps | 1. Open Dashboard |
+| Expected result | Low-stock ingredients are listed with current and minimum quantities. |
+| Status | Pending |
 
----
+### TC-27: Financial report export
 
-## 7. PWA + Offline
-
-### CP-27: Instalación como PWA
-
-| Campo | Detalle |
+| Field | Detail |
 |---|---|
-| **Pre-condición** | App desplegada en HTTPS (Firebase Hosting) |
-| **Pasos** | 1. Abrir en Chrome mobile <br> 2. Menú → "Agregar a pantalla de inicio" / banner automático |
-| **Resultado esperado** | ✅ Se instala con ícono propio <br> ✅ Se abre sin barra de navegación del browser <br> ✅ Nombre: "Lucis Gestión" |
-| **Estado** | ⏳ |
+| Precondition | Financial report data is available |
+| Steps | 1. Open Financial Reports 2. Generate PDF or Excel export |
+| Expected result | A report file is generated with KPIs, top products/customers, and insights. |
+| Status | Pending |
 
-### CP-28: Funcionamiento offline
+### TC-28: Fixed costs
 
-| Campo | Detalle |
+| Field | Detail |
 |---|---|
-| **Pre-condición** | App cargada previamente con datos sincronizados |
-| **Pasos** | 1. Activar modo avión <br> 2. Navegar entre pantallas <br> 3. Registrar una venta |
-| **Resultado esperado** | ✅ Datos previamente cargados se muestran <br> ✅ Navegación funciona <br> ✅ Venta se guarda localmente y se sincroniza al volver online |
-| **Estado** | ⏳ |
+| Precondition | Demo or owner user active |
+| Steps | 1. Open Fixed Costs 2. Register a monthly fixed cost 3. Review the list |
+| Expected result | The cost is stored and included in the monthly financial context. |
+| Status | Pending |
 
----
+## PWA and Deployment
 
-## 8. Ciclo completo (E2E)
+### TC-29: PWA installation
 
-### CP-29: Ciclo de negocio completo
-
-| Campo | Detalle |
+| Field | Detail |
 |---|---|
-| **Pre-condición** | App vacía, usuario logueado como owner |
-| **Pasos** | 1. Crear 3 ingredientes: Harina ($500/kg, stock 10), Azúcar ($400/kg, stock 5), Huevos ($200/doc, stock 6) <br> 2. Crear receta "Torta Chocolate": Harina 0.5kg + Azúcar 0.3kg + Huevos 1doc, margen 60% <br> 3. Crear cliente "Ana García", tel 5491155551234 <br> 4. Registrar venta: 3x Torta Chocolate para Ana, efectivo <br> 5. Verificar stock: Harina=8.5, Azúcar=3.1, Huevos=3 <br> 6. Ir a Dashboard → KPIs en "Hoy" <br> 7. Entregar el pedido <br> 8. Enviar Whatsapp a Ana desde clientes |
-| **Resultado esperado** | ✅ Costo receta = $570, precio sugerido = $912 <br> ✅ Venta total = $2,736 (3 × $912) <br> ✅ Stock se descuenta correctamente <br> ✅ Dashboard muestra $2,736 en ingresos del día <br> ✅ "Torta Chocolate" aparece como más vendido <br> ✅ Pedido cambia a entregado <br> ✅ WhatsApp abre con saludo correcto |
-| **Estado** | ⏳ |
+| Precondition | App is opened through HTTPS deployment |
+| Steps | 1. Open in Chrome 2. Use install/add-to-home-screen option |
+| Expected result | The app installs with its manifest name and icon. |
+| Status | Pending |
 
-### CP-30: Verificación de roles — Ayudante
+### TC-30: Direct deployed route refresh
 
-| Campo | Detalle |
+| Field | Detail |
 |---|---|
-| **Pre-condición** | Segundo usuario logueado con rol `ayudante` |
-| **Pasos** | 1. Intentar crear/editar ingrediente <br> 2. Intentar crear/editar receta <br> 3. Registrar una venta <br> 4. Crear un cliente nuevo |
-| **Resultado esperado** | ⚠️ Con las Firestore rules actuales: <br> ✅ Puede leer ingredientes y recetas <br> ❌ No puede crear/editar ingredientes ni recetas (Firestore reject) <br> ✅ Puede crear ventas y clientes <br> 🔍 **Nota**: La UI no esconde botones todavía — el ayudante verá los formularios pero Firestore rechazará el write |
-| **Estado** | ⏳ |
+| Precondition | Application deployed to Firebase Hosting |
+| Steps | 1. Open `/demo/dashboard` directly 2. Refresh browser |
+| Expected result | Firebase Hosting rewrites to the Angular app and the route loads correctly. |
+| Status | Pending |
 
----
+## End-to-end Business Flow
 
-## Checklist rápido de ejecución
+### TC-31: Complete bakery workflow
 
-| # | Caso | Estado |
+| Field | Detail |
+|---|---|
+| Precondition | Demo mode active |
+| Steps | 1. Review ingredients 2. Create or inspect recipe cost 3. Create customer 4. Register sale 5. Verify stock 6. Deliver order 7. Review dashboard 8. Export report |
+| Expected result | The application supports the complete operational cycle from production data to sale and reporting. |
+| Status | Pending |
+
+## Quick Execution Checklist
+
+| ID | Test case | Status |
 |---|---|---|
-| CP-01 | Login primer usuario (owner) | ⏳ |
-| CP-02 | Login segundo usuario (ayudante) | ⏳ |
-| CP-03 | Logout | ⏳ |
-| CP-04 | Acceso sin auth | ⏳ |
-| CP-05 | Crear ingrediente | ⏳ |
-| CP-06 | Editar ingrediente + cascada | ⏳ |
-| CP-07 | Buscar ingrediente | ⏳ |
-| CP-08 | Eliminar ingrediente | ⏳ |
-| CP-09 | Historial de precios | ⏳ |
-| CP-10 | Crear receta + cálculo | ⏳ |
-| CP-11 | Duplicar receta | ⏳ |
-| CP-12 | Compartir catálogo | ⏳ |
-| CP-13 | Imprimir catálogo | ⏳ |
-| CP-14 | Venta + descuento stock | ⏳ |
-| CP-15 | Marcar entregada | ⏳ |
-| CP-16 | Cancelar venta | ⏳ |
-| CP-17 | Buscar historial ventas | ⏳ |
-| CP-18 | WhatsApp desde venta | ⏳ |
-| CP-19 | Stock semáforo | ⏳ |
-| CP-20 | CRUD clientes | ⏳ |
-| CP-21 | WhatsApp desde cliente | ⏳ |
-| CP-22 | Buscar cliente | ⏳ |
-| CP-23 | KPIs + período | ⏳ |
-| CP-24 | Producto más vendido | ⏳ |
-| CP-25 | Ingresos vs Costos | ⏳ |
-| CP-26 | Alertas stock bajo | ⏳ |
-| CP-27 | PWA instalación | ⏳ |
-| CP-28 | Modo offline | ⏳ |
-| CP-29 | Ciclo E2E completo | ⏳ |
-| CP-30 | Verificación roles ayudante | ⏳ |
+| TC-01 | Demo access without login | Pending |
+| TC-02 | Google login for Firebase mode | Pending |
+| TC-03 | Logout | Pending |
+| TC-04 | Protected route access | Pending |
+| TC-05 | Create ingredient | Pending |
+| TC-06 | Edit ingredient price | Pending |
+| TC-07 | Search ingredient | Pending |
+| TC-08 | Delete ingredient | Pending |
+| TC-09 | Review price history | Pending |
+| TC-10 | Create recipe with cost calculation | Pending |
+| TC-11 | Duplicate recipe | Pending |
+| TC-12 | Share catalog | Pending |
+| TC-13 | Print catalog | Pending |
+| TC-14 | Register sale and deduct stock | Pending |
+| TC-15 | Mark sale as delivered | Pending |
+| TC-16 | Cancel sale | Pending |
+| TC-17 | Search sales history | Pending |
+| TC-18 | Send sale message by WhatsApp | Pending |
+| TC-19 | Stock traffic-light view | Pending |
+| TC-20 | Customer CRUD | Pending |
+| TC-21 | WhatsApp from customer card | Pending |
+| TC-22 | Search customer | Pending |
+| TC-23 | KPI period selector | Pending |
+| TC-24 | Best-selling product | Pending |
+| TC-25 | Revenue versus cost visualization | Pending |
+| TC-26 | Low-stock dashboard alert | Pending |
+| TC-27 | Financial report export | Pending |
+| TC-28 | Fixed costs | Pending |
+| TC-29 | PWA installation | Pending |
+| TC-30 | Direct deployed route refresh | Pending |
+| TC-31 | Complete bakery workflow | Pending |


### PR DESCRIPTION
### Motivation
- Provide a TFM-ready English documentation set so evaluators can review and run the project without extra setup. 
- Make the public demo the recommended evaluation path and include clear instructions to run a local demo mode that requires no Firebase credentials. 
- Supply slide content and a screen-recording video script so the presentation deliverables are included in the repository. 

### Description
- Rewrote `README.md` in English with a project overview, live deployment URL (`https://lucis-gestion-6cea2.web.app/`), demo access guidance, stack, install/run commands, project structure, features, and evaluation flow. 
- Updated the deployment guide at `read first/GUIA-DESPLIEGUE.md` to reflect current Angular/Firebase setup, environment configuration, and post-deploy checklist. 
- Replaced the manual test cases with an English functional test manual at `read first/MANUAL-CASOS-DE-PRUEBA.md` and added a slide deck source `docs/presentation/TFM-SLIDES.md` plus a video narration script `docs/video/TFM-VIDEO-SCRIPT.md`. 
- Updated `AGENTS.md` to reflect the current Angular 22 stack, demo workflow, documentation locations, and contributor guidance. 

### Testing
- Ran `pnpm build:mock` which completed successfully and produced the mock build artifacts. 
- Ran `pnpm test:mock` (the mock verification script) and the Vitest suite completed with `29 files passed` / `190 tests passed`. 
- Ran `pnpm lint` which completed successfully but reported one existing warning in `financial-report-pdf.service.spec.ts` for `@typescript-eslint/no-explicit-any`. 
- Attempted `pnpm exec playwright install chromium` to enable live screenshot capture but the browser download failed with a CDN `403 Forbidden`, so the automation used the fallback screenshot instead.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a366954d8908328b8b3554a2ee11c6c)